### PR TITLE
[admin] Fixing /report

### DIFF
--- a/[admin]/admin/client/gui/admin_report.lua
+++ b/[admin]/admin/client/gui/admin_report.lua
@@ -38,6 +38,10 @@ function aReport ( player )
 	end
 	guiBringToFront ( aReportForm )
 	showCursor ( true )
+	
+	if ( aAdminForm == null or guiGetVisible ( aAdminForm ) == false ) then
+		guiSetInputMode ( "no_binds_when_editing" )
+	end
 end
 addCommandHandler ( "report", aReport )
 
@@ -48,6 +52,10 @@ function aReportClose ( )
 		destroyElement ( aReportForm )
 		aReportForm = nil
 		showCursor ( false )
+		
+		if ( aAdminForm == null or guiGetVisible ( aAdminForm ) == false ) then
+			guiSetInputMode ( "allow_binds" )
+		end
 	end
 end
 

--- a/[admin]/admin/client/gui/admin_report.lua
+++ b/[admin]/admin/client/gui/admin_report.lua
@@ -83,7 +83,8 @@ function aClientReportClick ( button )
 			if ( ( string.len ( guiGetText ( aReportSubject ) ) < 1 ) or ( string.len ( guiGetText ( aReportMessage ) ) < 5 ) ) then
 				aMessageBox ( "error", "Subject/Message missing." )
 			else
-				aMessageBox ( "info", "Your message has been submited and will be processed as soon as possible." )
+				aMessageBox ( "info", "Your message has been submitted and will be processed as soon as possible." )
+				guiSetVisible ( aMessageOk, false )
 				setTimer ( aMessageBoxClose, 3000, 1, true )
 				local tableOut = {}
 				tableOut.category = guiGetText ( aReportCategory )

--- a/[admin]/admin/client/gui/admin_report.lua
+++ b/[admin]/admin/client/gui/admin_report.lua
@@ -37,9 +37,9 @@ function aReport ( player )
 		addEventHandler ( "onClientGUIDoubleClick", aReportForm, aClientReportDoubleClick )
 	end
 	guiBringToFront ( aReportForm )
-	showCursor ( true )
 	
 	if ( aAdminForm == null or guiGetVisible ( aAdminForm ) == false ) then
+		showCursor ( true )
 		guiSetInputMode ( "no_binds_when_editing" )
 	end
 end
@@ -51,9 +51,9 @@ function aReportClose ( )
 		removeEventHandler ( "onClientGUIDoubleClick", aReportForm, aClientReportDoubleClick )
 		destroyElement ( aReportForm )
 		aReportForm = nil
-		showCursor ( false )
 		
 		if ( aAdminForm == null or guiGetVisible ( aAdminForm ) == false ) then
+			showCursor ( false )
 			guiSetInputMode ( "allow_binds" )
 		end
 	end


### PR DESCRIPTION
The ```/report``` GUI doesn't disable keybinds, so (for example) typing a ```t``` into one of the input fields fires the chat bind and steals input focus. If you close the ```/report``` GUI while the admin panel is visible in the background, the mouse disappears and leaves a unusable admin panel. After successfully submitting a message, a small window (```aMessageBox```) is shown. The window also shows an Ok-button, which isn't reachable, because the mouse is already hidden. This misleads users to press ```Enter```, what is often a bound key (e.g. ```/kill``` in the race gamemod), even though the window is automatically hidden after 3 seconds.

**Steps To Reproduce**
1. load & start admin resource
2. login as admin
3. open admin panel (default: ```p```)
4. type ```/report```
5. focus is stolen when typing a bound key (e.g. ```t```) into one of the input fields (addressed by the first commit)
6.1. when closing the ```/report``` window, the mouse disappears while the admin panel is still visible (addressed by the second commit)
6.2. when submitting, a success message is shown as described above (addressed by the third commit)

**Mantis**
First commit: http://bugs.mtasa.com/view.php?id=8791
Second commit: -
Third commit: -