### PR TITLE
[freeroam] Warp to player with hex code doesn't work

### DIFF
--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -359,7 +359,7 @@ wndGravity = {
 ---------------------------
 
 function warpInit()
-	local players = table.map(getElementsByType('player'), function(p) return { name = getPlayerName(p) } end)
+	local players = table.map(getElementsByType('player'), function(p) return { player = p, name = getPlayerName(p) } end)
 	table.sort(players, function(a, b) return a.name < b.name end)
 	bindGridListToTable(wndWarp, 'playerlist', players, true)
 end
@@ -371,10 +371,7 @@ function warpTo(leaf)
 			return
 		end
 	end
-	local player = getPlayerFromName(leaf.name)
-	if player then
-		server.warpMe(player)
-	end
+	server.warpMe(leaf.player)
 	closeWindow(wndWarp)
 end
 

--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -371,7 +371,9 @@ function warpTo(leaf)
 			return
 		end
 	end
-	server.warpMe(leaf.player)
+	if isElement(leaf.player) then
+		server.warpMe(leaf.player)
+	end
 	closeWindow(wndWarp)
 end
 


### PR DESCRIPTION
Warp to players with hex codes in their name doesn't work when "removeHex" is set to true in the meta.