### PR TITLE
Re-added brownstreak carriage to vehicles list

### DIFF
--- a/[gameplay]/freeroam/vehicles.xml
+++ b/[gameplay]/freeroam/vehicles.xml
@@ -208,6 +208,7 @@
 			<vehicle id="424" name="BF Injection" />
 			<vehicle id="504" name="Bloodring Banger" />
 			<vehicle id="538" name="Brownstreak Engine" />
+			<vehicle id="570" name="Brownstreak Carriage" />
 			<vehicle id="431" name="Bus" />
 			<vehicle id="457" name="Caddy" />
 			<vehicle id="437" name="Coach" />


### PR DESCRIPTION
After the brownstreak carriage got re-enabled and fixed (r5934) it never got added to freeroam vehicles list.