### PR TITLE
Fix glitch of setting others' dimension as passenger

### DIFF
--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -889,8 +889,12 @@ wndSpawnMap = {
 ---------------------------
 
 function setInterior(leaf)
-	server.setElementInterior(g_Me, leaf.world)
 	local vehicle = getPedOccupiedVehicle(g_Me)
+	if vehicle and getVehicleController (vehicle) ~= g_Me then
+		outputChatBox ("* Only the driver may set interior/dimension", 255, 0, 0)
+		return
+	end
+	server.setElementInterior(g_Me, leaf.world)
 	if vehicle then
 		server.setElementInterior(vehicle, leaf.world)
 		for i=0,getVehicleMaxPassengers(vehicle) do


### PR DESCRIPTION
This fixes the abuse possible on Freeroam, if you get in another players' vehicle and F1 > int, setting interior. It won't since you aren't the driver, but as the dimension is set before this check, it will blank out their view on the world as dimension is changed already.

This glitch solves that by adding a check, thus preventing the annoying misuse of the bug, where they make the world for the driver invisible.