### PR TITLE
Fixed instant reload on sawnoff

### DIFF
--- a/[gameplay]/freeroam/fr_server.lua
+++ b/[gameplay]/freeroam/fr_server.lua
@@ -283,6 +283,7 @@ function warpMe(targetPlayer)
 	setCameraInterior(source, interior)
 end
 
+local sawnoffAntiAbuse = {}
 function giveMeWeapon(weapon, amount)
 	if weapon and weapon > 50 then
 		return
@@ -291,6 +292,19 @@ function giveMeWeapon(weapon, amount)
 		errMsg((getWeaponNameFromID(weapon) or tostring(weapon)) .. 's are not allowed', source)
 	else
 		giveWeapon(source, weapon, amount, true)
+		if weapon == 26 then
+			if not sawnoffAntiAbuse[source] then
+				setControlState (source, "aim_weapon", false)
+				setControlState (source, "fire", false)
+				toggleControl (source, "fire", false)
+				reloadPedWeapon (source)
+				sawnoffAntiAbuse[source] = setTimer (function(source)
+					if not source then return end
+					toggleControl (source, "fire", true)
+					sawnoffAntiAbuse[source] = nil
+				end, 3000, 1, source)
+			end
+        end
 	end
 end
 


### PR DESCRIPTION
This glitch was performed by switching to same weapon again, (/wp sawnoff) while in the very beginning of reload anim, cancelling it and evading it. If done quickly and fluently, switching between that /wp bind and constantly firing, will make you able to fire sawn-off rounds constantly and like an automatic, something disastrous seen the damage sawnoff shots do. That is now fixed and prevented with this, adding a forced reload on swapping sawnoff to interrupt the glitcher from progressing to constant firing & repeatedly cancelling reload.