### PR TITLE
Fix for rapid shooting glitch with slowfiring weapons

### DIFF
--- a/[gameplay]/realdriveby/driveby_client.lua
+++ b/[gameplay]/realdriveby/driveby_client.lua
@@ -286,3 +286,10 @@ function fadeOutHelp()
 	helpAnimation = Animation.createAndPlay(helpText, Animation.presets.dxTextFadeOut(300))
 	setTimer ( function() helpText:color(255,255,255,0) end, 300, 1 )
 end
+
+local function onWeaponSwitchWhileDriveby (prevSlot, curSlot)
+	if source == localPlayer and isPedDoingGangDriveby(source) then	
+		limitDrivebySpeed(getPedWeapon(source, curSlot))
+	end
+end
+addEventHandler ("onClientPlayerWeaponSwitch", localPlayer, onWeaponSwitchWhileDriveby)

--- a/[gameplay]/realdriveby/driveby_client.lua
+++ b/[gameplay]/realdriveby/driveby_client.lua
@@ -288,7 +288,7 @@ function fadeOutHelp()
 end
 
 local function onWeaponSwitchWhileDriveby (prevSlot, curSlot)
-	if source == localPlayer and isPedDoingGangDriveby(source) then	
+	if isPedDoingGangDriveby(source) then	
 		limitDrivebySpeed(getPedWeapon(source, curSlot))
 	end
 end


### PR DESCRIPTION
Because the weapon's defined shooting speeds weren't applied if the method to change a weapon during driveby was to directly set the weapon into wield slot, it ends up as an abusable glitch where you can get for example, Deagle to fire 7 rounds in around a second, this is disastrous seen the damage it does per shot.