### PR TITLE
[mapmanager] Fix for otherMapsContainer not having a header label

### DIFF
--- a/[managers]/mapmanager/mapmanager.js
+++ b/[managers]/mapmanager/mapmanager.js
@@ -59,6 +59,8 @@ function gamemodeListRefresh () {
 			otherMapsLabel.id = "none-label";
 			otherMapsLabel.className = "mapsheader";
 			otherMapsLabel.innerHTML = "non-gamemode maps";
+
+			otherMapsContainer.headerLabel = otherMapsLabel;
 			
 			mainContainer.appendChild ( otherMapsLabel );
 			mainContainer.appendChild ( otherMapsContainer );


### PR DESCRIPTION
To reproduce this make sure that all maps have a gamemode attribute in the info tag
in meta.xml (no maps with no gamemode set) then just click on the mapmanager in the
resourcebrowser

The error was: "Uncaught TypeError: Cannot read property 'style' of undefined"