### PR TITLE
Fix for #9061 (warp from interiors in freeroam)

### DIFF
--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -635,6 +635,12 @@ end
 
 function setPosClick()
 	setPlayerPosition(getControlNumbers(wndSetPos, {'x', 'y', 'z'}))
+	if getElementInterior(g_Me) ~= 0 then
+		if isPedInVehicle(g_Me) and getVehicleController(getPedOccupiedVehicle(g_Me)) == g_Me then
+			server.setElementInterior(getPedOccupiedVehicle(g_Me), 0)
+		end
+		server.setElementInterior(g_Me, 0)
+	end
 	closeWindow(wndSetPos)
 end
 


### PR DESCRIPTION
This fixes http://bugs.mtasa.com/view.php?id=9061 and lets it draw the world correctly after setting position from int.