### PR TITLE
[Freeroam] Addendum to fix for #9061

### DIFF
--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -636,7 +636,7 @@ end
 function setPosClick()
 	if setPlayerPosition(getControlNumbers(wndSetPos, {'x', 'y', 'z'})) ~= false then
 		if getElementInterior(g_Me) ~= 0 then
-			if isPedInVehicle(g_Me) and getVehicleController(getPedOccupiedVehicle(g_Me)) == g_Me then
+			if getPedOccupiedVehicle(g_Me) and getVehicleController(getPedOccupiedVehicle(g_Me)) == g_Me then
 				server.setElementInterior(getPedOccupiedVehicle(g_Me), 0)
 			end
 			server.setElementInterior(g_Me, 0)
@@ -649,7 +649,7 @@ function setPlayerPosition(x, y, z)
 	local elem = getPedOccupiedVehicle(g_Me)
 	local distanceToGround
 	local isVehicle
-	if elem and isPedInVehicle(g_Me) then
+	if elem and getPedOccupiedVehicle(g_Me) then
 		local controller = getVehicleController(elem)
 		if controller and controller ~= g_Me then
 			errMsg('Only the driver of the vehicle can set its position.')

--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -634,24 +634,26 @@ function fillInPosition(relX, relY, btn)
 end
 
 function setPosClick()
-	setPlayerPosition(getControlNumbers(wndSetPos, {'x', 'y', 'z'}))
-	if getElementInterior(g_Me) ~= 0 then
-		if isPedInVehicle(g_Me) and getVehicleController(getPedOccupiedVehicle(g_Me)) == g_Me then
-			server.setElementInterior(getPedOccupiedVehicle(g_Me), 0)
+	if setPlayerPosition(getControlNumbers(wndSetPos, {'x', 'y', 'z'})) ~= false then
+		if getElementInterior(g_Me) ~= 0 then
+			if isPedInVehicle(g_Me) and getVehicleController(getPedOccupiedVehicle(g_Me)) == g_Me then
+				server.setElementInterior(getPedOccupiedVehicle(g_Me), 0)
+			end
+			server.setElementInterior(g_Me, 0)
 		end
-		server.setElementInterior(g_Me, 0)
+		closeWindow(wndSetPos)
 	end
-	closeWindow(wndSetPos)
 end
 
 function setPlayerPosition(x, y, z)
 	local elem = getPedOccupiedVehicle(g_Me)
 	local distanceToGround
 	local isVehicle
-	if elem then
-		if getPlayerOccupiedSeat(g_Me) ~= 0 then
+	if elem and isPedInVehicle(g_Me) then
+		local controller = getVehicleController(elem)
+		if controller and controller ~= g_Me then
 			errMsg('Only the driver of the vehicle can set its position.')
-			return
+			return false
 		end
 		distanceToGround = getElementDistanceFromCentreOfMassToBaseOfModel(elem) + 3
 		isVehicle = true
@@ -683,7 +685,7 @@ function setPlayerPosition(x, y, z)
 					if isPedDead(g_Me) then
 						server.spawnMe(x, y, z)
 					else
-						setElementPosition(elem, x, y, z)
+						server.setMyPos(x, y, z)
 					end
 					setCameraPlayerMode()
 					setGravity(grav)
@@ -704,7 +706,7 @@ function setPlayerPosition(x, y, z)
 		if isPedDead(g_Me) then
 			server.spawnMe(x, y, z + distanceToGround)
 		else
-			setElementPosition(elem, x, y, z + distanceToGround)
+			server.setMyPos(x, y, z + distanceToGround)
 			if isVehicle then
 				setTimer(setElementVelocity, 100, 1, elem, 0, 0, 0)
 				setTimer(setVehicleTurnVelocity, 100, 1, elem, 0, 0, 0)

--- a/[gameplay]/freeroam/fr_server.lua
+++ b/[gameplay]/freeroam/fr_server.lua
@@ -255,10 +255,13 @@ function warpMe(targetPlayer)
 	end
 
 	local vehicle = getPedOccupiedVehicle(targetPlayer)
+	local interior = getElementInterior(targetPlayer)
 	if not vehicle then
 		-- target player is not in a vehicle - just warp next to him
 		local x, y, z = getElementPosition(targetPlayer)
 		clientCall(source, 'setPlayerPosition', x + 2, y, z)
+		setElementInterior(source, interior)
+		setCameraInterior(source, interior)
 	else
 		-- target player is in a vehicle - warp into it if there's space left
 		if getPedOccupiedVehicle(source) then
@@ -273,7 +276,6 @@ function warpMe(targetPlayer)
 					local x, y, z = getElementPosition(vehicle)
 					spawnMe(x + 4, y, z + 1)
 				end
-				local interior = getElementInterior(targetPlayer)
 				setElementInterior(source, interior)
 				setCameraInterior(source, interior)
 				warpPedIntoVehicle(source, vehicle, i)

--- a/[gameplay]/freeroam/fr_server.lua
+++ b/[gameplay]/freeroam/fr_server.lua
@@ -448,7 +448,7 @@ addEventHandler('onVehicleEnter', g_Root,
 )
 
 function setMyPos(x, y, z)
-	if not isElement(client) or getElementType(client) == "player" then
+	if not isElement(client) or getElementType(client) ~= "player" then
 		return
 	end 
 

--- a/[gameplay]/freeroam/fr_server.lua
+++ b/[gameplay]/freeroam/fr_server.lua
@@ -454,6 +454,7 @@ function setMyPos(x, y, z)
 			if getVehicleController (veh) then
 				if getVehicleController(veh) == source then
 					setElementPosition (veh, x, y, z)
+					setElementInterior (veh, getElementInterior (source))
 					for s = 1, getVehicleMaxPassengers (veh) do
 						local occ = getVehicleOccupant (veh, s)
 						if occ then

--- a/[gameplay]/freeroam/fr_server.lua
+++ b/[gameplay]/freeroam/fr_server.lua
@@ -58,7 +58,8 @@ g_RPCFunctions = {
 	setVehicleRotation = true,
 	setWeather = { option = 'weather', descr = 'Setting weather' },
 	spawnMe = true,
-	warpMe = { option = 'warp', descr = 'Warping' }
+	warpMe = { option = 'warp', descr = 'Warping' },
+	setMyPos = true
 }
 
 g_OptionDefaults = {
@@ -272,15 +273,15 @@ function warpMe(targetPlayer)
 					local x, y, z = getElementPosition(vehicle)
 					spawnMe(x + 4, y, z + 1)
 				end
+				local interior = getElementInterior(targetPlayer)
+				setElementInterior(source, interior)
+				setCameraInterior(source, interior)
 				warpPedIntoVehicle(source, vehicle, i)
 				return
 			end
 		end
 		outputChatBox('No free seats left in ' .. getPlayerName(targetPlayer) .. '\'s vehicle.', source, 255, 0, 0)
 	end
-	local interior = getElementInterior(targetPlayer)
-	setElementInterior(source, interior)
-	setCameraInterior(source, interior)
 end
 
 function giveMeWeapon(weapon, amount)
@@ -443,6 +444,29 @@ addEventHandler('onVehicleEnter', g_Root,
 		end
 	end
 )
+
+function setMyPos(x, y, z)
+	if isElement(source) and getElementType(source) == "player" then
+		if isPedInVehicle(source) then
+			local veh = getPedOccupiedVehicle (source)
+			if getVehicleController (veh) then
+				if getVehicleController(veh) == source then
+					setElementPosition (veh, x, y, z)
+					for s = 1, getVehicleMaxPassengers (veh) do
+						local occ = getVehicleOccupant (veh, s)
+						if occ then
+							setElementInterior (occ, getElementInterior(veh))
+						end
+					end
+				end
+			else
+				removePedFromVehicle(source)
+			end
+		end
+		setElementPosition (source, x, y, z)
+		fadeCamera (source, true)
+	end
+end
 
 addEventHandler('onVehicleExit', g_Root,
 	function(player, seat)

--- a/[gameplay]/freeroam/fr_server.lua
+++ b/[gameplay]/freeroam/fr_server.lua
@@ -448,27 +448,27 @@ addEventHandler('onVehicleEnter', g_Root,
 )
 
 function setMyPos(x, y, z)
-	if isElement(source) and getElementType(source) == "player" then
-		if isPedInVehicle(source) then
-			local veh = getPedOccupiedVehicle (source)
-			if getVehicleController (veh) then
-				if getVehicleController(veh) == source then
-					setElementPosition (veh, x, y, z)
-					setElementInterior (veh, getElementInterior (source))
-					for s = 1, getVehicleMaxPassengers (veh) do
-						local occ = getVehicleOccupant (veh, s)
-						if occ then
-							setElementInterior (occ, getElementInterior(veh))
-						end
-					end
+	if not isElement(client) or getElementType(client) == "player" then
+		return
+	end 
+
+	local veh = getPedOccupiedVehicle (client)
+	if veh then
+		if getVehicleController(veh) == client then
+			setElementPosition (veh, x, y, z)
+			setElementInterior (veh, getElementInterior (client))
+			for s = 1, getVehicleMaxPassengers (veh) do
+				local occ = getVehicleOccupant (veh, s)
+				if occ then
+					setElementInterior (occ, getElementInterior(veh))
 				end
-			else
-				removePedFromVehicle(source)
 			end
+		else
+			removePedFromVehicle(source)
 		end
-		setElementPosition (source, x, y, z)
-		fadeCamera (source, true)
 	end
+	setElementPosition (client, x, y, z)
+	fadeCamera (client, true)
 end
 
 addEventHandler('onVehicleExit', g_Root,


### PR DESCRIPTION
Improved patch to fit sbx320's recommendation:

'' We may want to move vehicle passangers into interior 0 as well and remove players from their vehicle if they're not the driver. ''

So now that's also done, plus you can warp yourself + vehicle & passengers straight to the main world from interiors if you drive the vehicle in an interior. Also fixed warping from interior into player's vehicles in main world directly, also won't create blank world anymore but render correctly