### PR TITLE
Fixed instant reload on sawnoff

### DIFF
--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -309,7 +309,11 @@ end
 function applyPlayerGrav()
 	local grav = getControlNumber(wndGravity, 'gravval')
 	if grav then
-		server.setPedGravity(g_Me, grav)
+		if not doesPedHaveJetPack (g_Me) then
+			server.setPedGravity(g_Me, grav)
+		else
+			outputChatBox ("* Error: #FFFFFFYou can not set gravity while having a jetpack", 255, 0, 0, true)
+		end
 	end
 	closeWindow(wndGravity)
 end
@@ -317,7 +321,11 @@ end
 function setGravityCommand(cmd, grav)
 	local grav = grav and tonumber(grav)
 	if grav then
-		server.setPedGravity(g_Me, tonumber(grav))
+		if not doesPedHaveJetPack (g_Me) then
+			server.setPedGravity(g_Me, tonumber(grav))
+		else
+			outputChatBox ("* Error: #FFFFFFYou can not set gravity while having a jetpack", 255, 0, 0, true)
+		end
 	end
 end
 addCommandHandler('setgravity', setGravityCommand)

--- a/[gameplay]/freeroam/fr_server.lua
+++ b/[gameplay]/freeroam/fr_server.lua
@@ -286,6 +286,7 @@ function warpMe(targetPlayer)
 	end
 end
 
+local sawnoffAntiAbuse = {}
 function giveMeWeapon(weapon, amount)
 	if weapon and weapon > 50 then
 		return
@@ -294,8 +295,29 @@ function giveMeWeapon(weapon, amount)
 		errMsg((getWeaponNameFromID(weapon) or tostring(weapon)) .. 's are not allowed', source)
 	else
 		giveWeapon(source, weapon, amount, true)
+		if weapon == 26 then
+			if not sawnoffAntiAbuse[source] then
+				setControlState (source, "aim_weapon", false)
+				setControlState (source, "fire", false)
+				toggleControl (source, "fire", false)
+				reloadPedWeapon (source)
+				sawnoffAntiAbuse[source] = setTimer (function(source)
+					if not source then return end
+					toggleControl (source, "fire", true)
+					sawnoffAntiAbuse[source] = nil
+				end, 3000, 1, source)
+			end
+        end
 	end
 end
+
+function killSawnOffTimersOnQuit()
+	if isTimer (sawnoffAntiAbuse[source]) then
+		killTimer (sawnoffAntiAbuse[source])
+		sawnoffAntiAbuse[source] = nil
+	end
+end
+addEventHandler ("onPlayerQuit", root, killSawnOffTimersOnQuit)
 
 function giveMeVehicles(vehicles)
 	if type(vehicles) == 'number' then

--- a/[gameplay]/freeroam/fr_server.lua
+++ b/[gameplay]/freeroam/fr_server.lua
@@ -583,6 +583,15 @@ addEventHandler('onServerCall', resourceRoot,
 	function(fnName, ...)
 		source = client		-- Some called functions require 'source' to be set to the triggering client
 		local fnInfo = g_RPCFunctions[fnName]
+
+		-- Custom check made to intercept the jetpack on custom gravity
+		if fnInfo and type(fnInfo) ~= "boolean" and tostring(fnInfo.option) == "jetpack" then
+			if tonumber(("%.3f"):format(getPedGravity(source))) ~= 0.008 then
+				errMsg("* You may use jetpack only if the gravity is set to 0.008", source)
+				return
+			end
+		end
+
 		if fnInfo and ((type(fnInfo) == 'boolean' and fnInfo) or (type(fnInfo) == 'table' and getOption(fnInfo.option))) then
 			local fn = _G
 			for i,pathpart in ipairs(fnName:split('.')) do


### PR DESCRIPTION
This is a remake of old PR: https://github.com/multitheftauto/mtasa-resources/pull/20 due to repo mismatch.

Glitch was performed by switching to same weapon again, (/wp sawnoff) while in the very beginning of reload anim, cancelling it and evading it. If done quickly and fluently, switching between that /wp bind and constantly firing, will make you able to fire sawn-off rounds constantly and like an automatic, something disastrous seen the damage sawnoff shots do. That is now fixed and prevented with this, adding a forced reload on swapping sawnoff to interrupt the glitcher from progressing to constant firing & repeatedly cancelling reload.

New PR includes the quithandler ccw suggested for it to fit coding standards, and avoiding isElement (we have a proper quithandler now) so that second change included in old PR wasnt added now.