### PR TITLE
Fixed instant reload on sawnoff

### DIFF
--- a/[gameplay]/freeroam/fr_server.lua
+++ b/[gameplay]/freeroam/fr_server.lua
@@ -286,6 +286,7 @@ function warpMe(targetPlayer)
 	end
 end
 
+local sawnoffAntiAbuse = {}
 function giveMeWeapon(weapon, amount)
 	if weapon and weapon > 50 then
 		return
@@ -294,8 +295,29 @@ function giveMeWeapon(weapon, amount)
 		errMsg((getWeaponNameFromID(weapon) or tostring(weapon)) .. 's are not allowed', source)
 	else
 		giveWeapon(source, weapon, amount, true)
+		if weapon == 26 then
+			if not sawnoffAntiAbuse[source] then
+				setControlState (source, "aim_weapon", false)
+				setControlState (source, "fire", false)
+				toggleControl (source, "fire", false)
+				reloadPedWeapon (source)
+				sawnoffAntiAbuse[source] = setTimer (function(source)
+					if not source then return end
+					toggleControl (source, "fire", true)
+					sawnoffAntiAbuse[source] = nil
+				end, 3000, 1, source)
+			end
+        end
 	end
 end
+
+function killSawnOffTimersOnQuit()
+	if isTimer (sawnoffAntiAbuse[source]) then
+		killTimer (sawnoffAntiAbuse[source])
+		sawnoffAntiAbuse[source] = nil
+	end
+end
+addEventHandler ("onPlayerQuit", root, killSawnOffTimersOnQuit)
 
 function giveMeVehicles(vehicles)
 	if type(vehicles) == 'number' then


### PR DESCRIPTION
This is a second remake of old PR: #20 due to repo mismatch. (other remake failed due to some unintended commit linking)

Glitch was performed by switching to same weapon again, (/wp 26) (sawnoff) while in the very beginning of reload anim, cancelling it and evading it. If done quickly and fluently, switching between that /wp bind and constantly firing, will make you able to fire sawn-off rounds constantly and like an automatic, something disastrous seen the damage sawnoff shots do. That is now fixed and prevented with this, adding a forced reload on swapping sawnoff to interrupt the glitcher from progressing to constant firing & repeatedly cancelling reload.

New PR includes the quithandler ccw suggested for it to fit coding standards, and avoiding isElement (we have a proper quithandler now) so that second change included in old PR wasnt added now.