### PR TITLE
Add GUI options on serial / IP ban: Reason & nick

### DIFF
--- a/[admin]/admin/client/gui/admin_inputbox.lua
+++ b/[admin]/admin/client/gui/admin_inputbox.lua
@@ -1,4 +1,4 @@
-﻿--[[**********************************
+--[[**********************************
 *
 *	Multi Theft Auto - Admin Panel
 *
@@ -29,6 +29,32 @@ function aInputBox ( title, message, default, action, vOne, vTwo )
 		--Register With Admin Form
 		aRegister ( "InputBox", aInputForm, aInputBox, aInputBoxClose )
 	end
+	if not action or action ~= "banSerial" and action ~= "banIP" then
+		guiSetSize(aInputForm, 300, 110, false)
+		guiSetPosition(aInputOk, 90, 80, false)
+		guiSetPosition(aInputCancel, 150, 80, false)
+
+		if isElement(banSerialLbl) then destroyElement(banSerialLbl) end
+		if isElement(banNickEdit) then destroyElement(banNickEdit) end
+		if isElement(banReasonEdit) then destroyElement(banReasonEdit) end
+	else
+		guiSetSize(aInputForm, 300, 170, false)
+		guiSetPosition(aInputOk, 90, 140, false)
+		guiSetPosition(aInputCancel, 150, 140, false)
+
+		if not isElement(banSerialLbl) then
+			banSerialLbl = guiCreateLabel ( 20, 75, 270, 15, "Enter player nick & reason", false, aInputForm )
+			guiLabelSetHorizontalAlign ( banSerialLbl, "center" )
+		end
+		if not isElement(banNickEdit) then
+			banNickEdit = guiCreateEdit ( 35, 95, 60, 24, "Nick", false, aInputForm )
+		end
+		if not isElement(banReasonEdit) then
+			banReasonEdit = guiCreateEdit ( 100, 95, 165, 24, "Reason", false, aInputForm )
+		end
+	end
+	
+
 	guiSetText ( aInputForm, title )
 	guiSetText ( aInputLabel, message )
 	guiSetText ( aInputValue, default )
@@ -99,9 +125,9 @@ function aInputBoxClick ( button )
 			elseif (aInputAction == "unbanSerial") then
 				triggerServerEvent("aBans", localPlayer, "unbanserial", guiGetText(aInputValue))
 			elseif (aInputAction == "banIP") then
-				triggerServerEvent("aBans", localPlayer, "banip", guiGetText(aInputValue))
+				triggerServerEvent("aBans", localPlayer, "banip", guiGetText(aInputValue), guiGetText(banNickEdit), guiGetText(banReasonEdit))
 			elseif (aInputAction == "banSerial") then
-				triggerServerEvent("aBans", localPlayer, "banserial", guiGetText(aInputValue))
+				triggerServerEvent("aBans", localPlayer, "banserial", guiGetText(aInputValue), guiGetText(banNickEdit), guiGetText(banReasonEdit))
 			elseif (aInputAction == "settingChange") then
 				triggerServerEvent("aAdmin", localPlayer, "settings", "change", varOne, varTwo, guiGetText(aInputValue))
 			elseif (aInputAction == "aclCreateGroup") then

--- a/[admin]/admin/server/admin_server.lua
+++ b/[admin]/admin/server/admin_server.lua
@@ -1,4 +1,4 @@
-﻿--[[**********************************
+--[[**********************************
 *
 *	Multi Theft Auto - Admin Panel
 *
@@ -853,14 +853,23 @@ addEventHandler ( "aPlayer", _root, function ( player, action, data, additional,
 					end, 100, 1)
 					
 				else
-					setTimer ( addBan, 100, 1, nil, nil, getPlayerSerial(player), source, reason, seconds or 0 )
+					setTimer ( function()
+						local tBan = addBan( nil, nil, getPlayerSerial(player), source, reason, seconds or 0 )
+						setBanAdmin(tBan,adminAccountName)
+					end, 100, 1)
 				end
 			else
 				outputChatBox ( "You banned IP " .. getPlayerIP( player ), source, 255, 100, 70 )
 				if isAnonAdmin then
-					setTimer ( banPlayer, 100, 1, player, true, false, false, nil, reason, seconds or 0 )
+					setTimer ( function()
+						local tBan = banPlayer( player, true, false, false, nil, reason, seconds or 0 )
+						setBanAdmin(tBan,adminAccountName)
+					end, 100, 1)
 				else
-					setTimer ( banPlayer, 100, 1, player, true, false, false, source, reason, seconds or 0 )
+					setTimer ( function()
+						local tBan = banPlayer( player, true, false, false, source, reason, seconds or 0 )
+						setBanAdmin(tBan,adminAccountName)
+					end, 100, 1)
 				end
 			end
 			setTimer( triggerEvent, 1000, 1, "aSync", _root, "bansdirty" )
@@ -1378,21 +1387,27 @@ addEventHandler ( "aModdetails", resourceRoot, function ( action, player )
 end )
 
 addEvent ( "aBans", true )
-addEventHandler ( "aBans", _root, function ( action, data )
+addEventHandler ( "aBans", _root, function ( action, data, arg1, arg2 )
 	if checkClient( "command."..action, source, 'aBans', action ) then return end
 	if ( hasObjectPermissionTo ( source, "command."..action ) ) then
 		local mdata = ""
 		local more = ""
 		if ( action == "banip" ) then
 			mdata = data
-			if ( not addBan ( data,nil,nil,source ) ) then
+			local newban = addBan ( data,nil,nil,source,arg2 )
+			if ( not newban ) then
 				action = nil
+			else
+				setBanNick (newban, arg1)
 			end
 		elseif ( action == "banserial" ) then
 			mdata = data
 			if ( isValidSerial ( data ) ) then
-				if ( not addBan ( nil,nil, string.upper ( data ),source ) ) then
+				local newban = addBan ( nil,nil, string.upper ( data ),source,arg2 )
+				if ( not newban ) then
 					action = nil
+				else
+					setBanNick (newban, arg1)
 				end
 			else
 				outputChatBox ( "Error - Invalid serial", source, 255, 0, 0 )


### PR DESCRIPTION
Implement possibility to manually add ban reason & player nick when banning a specific serial / IP of offline player through adminpanel ''Ban Serial'' or ''Ban IP'' button.
Previously, customly entering bans per serial / IP in adminpanel resulted in reason-less / nick-less bans that only contained the serial or IP in banlist.

This PR adds 2 fields to the ''Ban serial'' and ''Ban IP'' buttons to enter reason & nickname.