### PR TITLE
Addendum to PR #48: fix inconsistency

### DIFF
--- a/[admin]/admin/server/admin_server.lua
+++ b/[admin]/admin/server/admin_server.lua
@@ -1399,6 +1399,7 @@ addEventHandler ( "aBans", _root, function ( action, data, arg1, arg2 )
 				action = nil
 			else
 				setBanNick (newban, arg1)
+				setBanAdmin(newban, getAccountName(getPlayerAccount(source)))
 			end
 		elseif ( action == "banserial" ) then
 			mdata = data
@@ -1407,6 +1408,7 @@ addEventHandler ( "aBans", _root, function ( action, data, arg1, arg2 )
 				if ( not newban ) then
 					action = nil
 				else
+					setBanAdmin(newban, getAccountName(getPlayerAccount(source)))
 					setBanNick (newban, arg1)
 				end
 			else


### PR DESCRIPTION
This commit fixes something I missed out on last PR #48; conform all bans to set banning admin to their accountname instead of nick.
It was meant to be the main feature of custom serial & IP ban, yet I missed it on these especially.