### PR TITLE
Add unban date to bans and allow defining custom ban times for offline bans

### DIFF
--- a/[admin]/admin/client/gui/admin_ban.lua
+++ b/[admin]/admin/client/gui/admin_ban.lua
@@ -1,4 +1,4 @@
-﻿--[[**********************************
+--[[**********************************
 *
 *	Multi Theft Auto - Admin Panel
 *
@@ -19,6 +19,7 @@ function aBanDetails ( ip )
 		aBanDate		= guiCreateLabel ( 0.03, 0.30, 0.80, 0.09, "", true, aBanForm )
 		aBanTime		= guiCreateLabel ( 0.03, 0.40, 0.80, 0.09, "", true, aBanForm )
 		aBanBanner		= guiCreateLabel ( 0.03, 0.50, 0.80, 0.09, "", true, aBanForm )
+		aBanUnban		= guiCreateLabel ( 0.03, 0.60, 0.80, 0.09, "", true, aBanForm )
 		aBanClose		= guiCreateButton ( 0.80, 0.88, 0.17, 0.08, "Close", true, aBanForm )
 
 		guiSetVisible ( aBanForm, false )
@@ -32,8 +33,14 @@ function aBanDetails ( ip )
 		guiSetText ( aBanDate, "Date: "..iif ( aBans["IP"][ip]["date"], aBans["IP"][ip]["date"], "Unknown" ) )
 		guiSetText ( aBanTime, "Time: "..iif ( aBans["IP"][ip]["time"], aBans["IP"][ip]["time"], "Unknown" ) )
 		guiSetText ( aBanBanner, "Banned by: "..iif ( aBans["IP"][ip]["banner"], aBans["IP"][ip]["banner"], "Unknown" ) )
+		local unban = tostring(aBans["IP"][ip]["unban"])
+		if not unban or unban == "0" then
+			guiSetText ( aBanUnban, "Unban: Permanent", unban)
+		else
+			guiSetText ( aBanUnban, "Unban: "..FormatDate("d/m/y h:i:s", "'", unban) )
+		end
 		if ( aBanReason ) then destroyElement ( aBanReason ) end
-		aBanReason = guiCreateLabel ( 0.03, 0.60, 0.80, 0.30, "Reason: "..iif ( aBans["IP"][ip]["reason"], aBans["IP"][ip]["reason"], "Unknown" ), true, aBanForm )
+		aBanReason = guiCreateLabel ( 0.03, 0.70, 0.80, 0.30, "Reason: "..iif ( aBans["IP"][ip]["reason"], aBans["IP"][ip]["reason"], "Unknown" ), true, aBanForm )
 		guiLabelSetHorizontalAlign ( aBanReason, "left", true )
 		guiSetVisible ( aBanForm, true )
 		guiBringToFront ( aBanForm )
@@ -43,8 +50,14 @@ function aBanDetails ( ip )
 		guiSetText ( aBanDate, "Date: "..iif ( aBans["Serial"][ip]["date"], aBans["Serial"][ip]["date"], "Unknown" ) )
 		guiSetText ( aBanTime, "Time: "..iif ( aBans["Serial"][ip]["time"], aBans["Serial"][ip]["time"], "Unknown" ) )
 		guiSetText ( aBanBanner, "Banned by: "..iif ( aBans["Serial"][ip]["banner"], aBans["Serial"][ip]["banner"], "Unknown" ) )
+		local unban = tostring(aBans["Serial"][ip]["unban"])
+		if not unban or unban == "0" then
+			guiSetText ( aBanUnban, "Unban: Permanent", unban)
+		else
+			guiSetText ( aBanUnban, "Unban: "..FormatDate("d/m/y h:i:s", "'", unban) )
+		end
 		if ( aBanReason ) then destroyElement ( aBanReason ) end
-		aBanReason = guiCreateLabel ( 0.03, 0.60, 0.80, 0.30, "Reason: "..iif ( aBans["Serial"][ip]["reason"], aBans["Serial"][ip]["reason"], "Unknown" ), true, aBanForm )
+		aBanReason = guiCreateLabel ( 0.03, 0.70, 0.80, 0.30, "Reason: "..iif ( aBans["Serial"][ip]["reason"], aBans["Serial"][ip]["reason"], "Unknown" ), true, aBanForm )
 		guiLabelSetHorizontalAlign ( aBanReason, "left", true )
 		guiSetVisible ( aBanForm, true )
 		guiBringToFront ( aBanForm )

--- a/[admin]/admin/client/gui/admin_inputbox.lua
+++ b/[admin]/admin/client/gui/admin_inputbox.lua
@@ -14,7 +14,7 @@ local varOne, varTwo = nil, nil
 function aInputBox ( title, message, default, action, vOne, vTwo )
 	if ( aInputForm == nil ) then
 		local x, y = guiGetScreenSize()
-		aInputForm		= guiCreateWindow ( x / 2 - 150, y / 2 - 64, 300, 110, "", false )
+		aInputForm		= guiCreateWindow ( x / 2 - 150, y / 2 - 64, 300, 170, "", false )
 				  	   guiWindowSetSizable ( aInputForm, false )
 		aInputLabel		= guiCreateLabel ( 20, 24, 270, 15, "", false, aInputForm )
 					   guiLabelSetHorizontalAlign ( aInputLabel, "center" )
@@ -30,28 +30,53 @@ function aInputBox ( title, message, default, action, vOne, vTwo )
 		aRegister ( "InputBox", aInputForm, aInputBox, aInputBoxClose )
 	end
 	if not action or action ~= "banSerial" and action ~= "banIP" then
-		guiSetSize(aInputForm, 300, 110, false)
+		guiSetSize(aInputForm, 300, 170, false)
 		guiSetPosition(aInputOk, 90, 80, false)
 		guiSetPosition(aInputCancel, 150, 80, false)
 
 		if isElement(banSerialLbl) then destroyElement(banSerialLbl) end
 		if isElement(banNickEdit) then destroyElement(banNickEdit) end
 		if isElement(banReasonEdit) then destroyElement(banReasonEdit) end
+		if isElement(banSerialCombo) then destroyElement(banSerialCombo) end
+		if isElement(banDurationLbl) then destroyElement(banDurationLbl) end
+		if isElement(durationEdit) then destroyElement(durationEdit) end
 	else
-		guiSetSize(aInputForm, 300, 170, false)
-		guiSetPosition(aInputOk, 90, 140, false)
-		guiSetPosition(aInputCancel, 150, 140, false)
+		guiSetSize(aInputForm, 300, 210, false)
+		guiSetPosition(aInputOk, 90, 180, false)
+		guiSetPosition(aInputCancel, 150, 180, false)
+		
+
+		-- time duration:
+
+		if not isElement(banSerialCombo) then
+			banSerialCombo = guiCreateComboBox ( 180, 135, 75, 4*20+20, "Perm", false, aInputForm )
+				guiComboBoxAddItem(banSerialCombo, "Mins")
+				guiComboBoxAddItem(banSerialCombo, "Hours")
+				guiComboBoxAddItem(banSerialCombo, "Days")
+				guiComboBoxAddItem(banSerialCombo, "Perm")
+		end
+
+		if not isElement(durationEdit) then
+			durationEdit = guiCreateEdit ( 110, 135, 60, 24, "", false, aInputForm )
+		end
+
+		if not isElement(banDurationLbl) then
+			banDurationLbl = guiCreateLabel ( 40, 138, 50, 15, "Duration:", false, aInputForm )
+			guiLabelSetHorizontalAlign ( banDurationLbl, "center" )
+		end
 
 		if not isElement(banSerialLbl) then
 			banSerialLbl = guiCreateLabel ( 20, 75, 270, 15, "Enter player nick & reason", false, aInputForm )
 			guiLabelSetHorizontalAlign ( banSerialLbl, "center" )
 		end
 		if not isElement(banNickEdit) then
-			banNickEdit = guiCreateEdit ( 35, 95, 60, 24, "Nick", false, aInputForm )
+			banNickEdit = guiCreateEdit ( 35, 95, 60, 24, "", false, aInputForm )
 		end
+		guiSetText(banNickEdit, "Nick")
 		if not isElement(banReasonEdit) then
-			banReasonEdit = guiCreateEdit ( 100, 95, 165, 24, "Reason", false, aInputForm )
+			banReasonEdit = guiCreateEdit ( 100, 95, 165, 24, "", false, aInputForm )
 		end
+		guiSetText(banReasonEdit, "Reason")
 	end
 	
 
@@ -124,10 +149,29 @@ function aInputBoxClick ( button )
 				triggerServerEvent("aBans", localPlayer, "unbanip", guiGetText(aInputValue))
 			elseif (aInputAction == "unbanSerial") then
 				triggerServerEvent("aBans", localPlayer, "unbanserial", guiGetText(aInputValue))
-			elseif (aInputAction == "banIP") then
-				triggerServerEvent("aBans", localPlayer, "banip", guiGetText(aInputValue), guiGetText(banNickEdit), guiGetText(banReasonEdit))
-			elseif (aInputAction == "banSerial") then
-				triggerServerEvent("aBans", localPlayer, "banserial", guiGetText(aInputValue), guiGetText(banNickEdit), guiGetText(banReasonEdit))
+			elseif (aInputAction == "banIP") or (aInputAction == "banSerial") then
+				local theDuration = 0
+				local durType = guiGetText(banSerialCombo)
+				if durType and durType ~= "Perm" then
+					-- First validate entry, must be a number
+					local durEntry = tonumber(guiGetText(durationEdit))
+					if not durEntry or type(durEntry) ~= "number" then
+						return outputChatBox("* Error: Enter a valid numeric duration value", 255, 0, 0)
+					else
+						if durType == "Mins" then
+							theDuration = math.floor(math.abs(durEntry)) * 60
+						elseif durType == "Hours" then
+							theDuration = math.floor(math.abs(durEntry)) * 60 * 60
+						elseif durType == "Days" then
+							theDuration = math.floor(math.abs(durEntry)) * 24 * 60 * 60
+						end
+					end
+				end
+				if aInputAction == "banIP" then
+					triggerServerEvent("aBans", localPlayer, "banip", guiGetText(aInputValue), guiGetText(banNickEdit), guiGetText(banReasonEdit), theDuration)
+				elseif aInputAction == "banSerial" then
+					triggerServerEvent("aBans", localPlayer, "banserial", guiGetText(aInputValue), guiGetText(banNickEdit), guiGetText(banReasonEdit), theDuration)
+				end
 			elseif (aInputAction == "settingChange") then
 				triggerServerEvent("aAdmin", localPlayer, "settings", "change", varOne, varTwo, guiGetText(aInputValue))
 			elseif (aInputAction == "aclCreateGroup") then
@@ -481,4 +525,3 @@ function aMuteInputBoxFinish ()
 		guiRadioButtonSetSelected( aMuteInputRadio2s[i], false ) 
 	end
 end
-

--- a/[admin]/admin/server/admin_server.lua
+++ b/[admin]/admin/server/admin_server.lua
@@ -1387,14 +1387,14 @@ addEventHandler ( "aModdetails", resourceRoot, function ( action, player )
 end )
 
 addEvent ( "aBans", true )
-addEventHandler ( "aBans", _root, function ( action, data, arg1, arg2 )
+addEventHandler ( "aBans", _root, function ( action, data, arg1, arg2, arg3 )
 	if checkClient( "command."..action, source, 'aBans', action ) then return end
 	if ( hasObjectPermissionTo ( source, "command."..action ) ) then
 		local mdata = ""
 		local more = ""
 		if ( action == "banip" ) then
 			mdata = data
-			local newban = addBan ( data,nil,nil,source,arg2 )
+			local newban = addBan ( data,nil,nil,source,arg2, arg3 )
 			if ( not newban ) then
 				action = nil
 			else
@@ -1404,7 +1404,7 @@ addEventHandler ( "aBans", _root, function ( action, data, arg1, arg2 )
 		elseif ( action == "banserial" ) then
 			mdata = data
 			if ( isValidSerial ( data ) ) then
-				local newban = addBan ( nil,nil, string.upper ( data ),source,arg2 )
+				local newban = addBan ( nil,nil, string.upper ( data ),source,arg2, arg3 )
 				if ( not newban ) then
 					action = nil
 				else

--- a/[admin]/admin/server/admin_sync.lua
+++ b/[admin]/admin/server/admin_sync.lua
@@ -1,4 +1,4 @@
-﻿--[[**********************************
+--[[**********************************
 *
 *	Multi Theft Auto - Admin Panel
 *
@@ -163,6 +163,7 @@ function aSynchCoroutineFunc( type, data )
 			tableOut[i].ip = getBanIP(ban)
 			tableOut[i].serial = getBanSerial(ban)
 			tableOut[i].reason = getBanReason(ban)
+			tableOut[i].unban = getUnbanTime(ban)
 		end
 	elseif ( type == "messages" ) then
 		local unread, total = 0, 0
@@ -391,4 +392,3 @@ function getPlayerACInfo( player )
 	end
 	return _getPlayerACInfo( player )
 end
-


### PR DESCRIPTION
This commit introduces the feature of entering custom ban times for offline bans (Ban serial or Ban IP) where before this they could only be permanent until manually removed from banlist.
It also adds ''Unban time'' columns to adminpanel banlist (scroll in banlist properties + Ban details field) that calculates the ban times from Unix to date/time (format of timestamps banlist.xml uses) so both new and existing bans will get the unban date attached and visible.

Ignore the PR's commit numberings.