### PR TITLE
Let the editor EDF scriptreader support OOP

### DIFF
--- a/[editor]/edf/meta.xml
+++ b/[editor]/edf/meta.xml
@@ -17,6 +17,7 @@
 	<script src="scriptreaderkeybinds.lua" type="client" />
 	<script src="scriptreader.lua" />
 	<script src="scriptreader_client.lua" type="client" />
+	<oop>true</oop>
 	
 	<export function="edfStartResource" />				<!--bool-->
 	<export function="edfStopResource" />				<!--bool-->	


### PR DESCRIPTION
Doesn't break anything and allows resource developers to use OOP in resources with editor support