### PR TITLE
Fixed /anim abusable glitch

### DIFF
--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -114,6 +114,11 @@ wndAnim = {
 
 addCommandHandler('anim',
 	function(command, lib, name)
+		if lib and name then
+		if string.lower(lib) == "finale" and string.lower(name) == "fin_jump_on" or string.lower(lib) == "finale2" and string.lower(name) == "fin_cop1_climbout" then
+			return outputChatBox ("* This animation may not be set by a command", 255, 0, 0)
+			end
+		end
 		server.setPedAnimation(g_Me, lib, name, true, true)
 	end
 )

--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -114,10 +114,12 @@ wndAnim = {
 
 addCommandHandler('anim',
 	function(command, lib, name)
-		if lib and name then
-		if string.lower(lib) == "finale" and string.lower(name) == "fin_jump_on" or string.lower(lib) == "finale2" and string.lower(name) == "fin_cop1_climbout" then
-			return outputChatBox ("* This animation may not be set by a command", 255, 0, 0)
-			end
+		if lib and name and (
+			(lib:lower() == "finale" and name:lower() == "fin_jump_on") or
+			(lib:lower() == "finale2" and name:lower() == "fin_cop1_climbout")
+		) then
+			errMsg('This animation may not be set by command.')
+			return
 		end
 		server.setPedAnimation(g_Me, lib, name, true, true)
 	end


### PR DESCRIPTION
This patch blocks 2 anims from being used directly by /anim command rather than GUI, because they were abusable in combat with other players; the anim makes their ped go underground (under the world) so that they suddenly become invisible and unharmable by gunfire since within split second they'd be gone from sight (in reality just under the attacker's feet)

It could be used by command at the moment player almost dies with low HP, to prevent any attack from other player to succeed. It's unfair advantage.