### PR TITLE
Added freeroam anti-command spam to block crafted attack methods to cause lag

### DIFF
--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -208,6 +208,7 @@ wndWeapon = {
 }
 
 function giveWeaponCommand(cmd, weapon, amount)
+	if isCommandOnCD(cmd) then return end
 	weapon = tonumber(weapon) or getWeaponIDFromName(weapon)
 	if not weapon then
 		return
@@ -366,6 +367,7 @@ function applyPlayerGrav()
 end
 
 function setGravityCommand(cmd, grav)
+	if isCommandOnCD(cmd) then return end
 	local grav = grav and tonumber(grav)
 	if grav then
 		server.setPedGravity(g_Me, tonumber(grav))
@@ -450,6 +452,7 @@ wndWarp = {
 }
 
 function warpToCommand(cmd, player)
+	if isCommandOnCD(cmd) then return end
 	if player then
 		player = getPlayerFromName(player)
 		if player then
@@ -1024,6 +1027,7 @@ wndCreateVehicle = {
 }
 
 function createVehicleCommand(cmd, ...)
+	if isCommandOnCD(cmd) then return end
 	local vehID
 	local vehiclesToCreate = {}
 	local args = { ... }

--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -8,6 +8,15 @@ g_Me = getLocalPlayer()
 server = createServerCallInterface()
 guiSetInputMode("no_binds_when_editing")
 
+-- Freeroam cooldown timer for commands (miliseconds, 1000 = 1 sec):
+local frCommandCooldownTime = 2000
+
+-- Place to store our cmd cooldown timers:
+local commandCDTimers = {}
+
+function cmdCDActive(cmd)
+	outputChatBox ("* Failed, don't spam the '"..tostring(cmd).."' command! *", 255, 0, 0)
+end
 ---------------------------
 -- Set skin window
 ---------------------------
@@ -56,6 +65,10 @@ wndSkin = {
 }
 
 function setSkinCommand(cmd, skin)
+	if cmd then
+		if isTimer(commandCDTimers[cmd]) then cmdCDActive(cmd) return end
+		commandCDTimers[cmd] = setTimer(function()end, frCommandCooldownTime, 1)
+	end
 	skin = skin and tonumber(skin)
 	if skin then
 		server.setMySkin(skin)

--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -37,13 +37,13 @@ function isCommandOnCD(cmd, exception)
 	-- check if a global cd is active
 	if command_ddos_protection == "true" and global_cooldown ~= 0 then
 		if tick - global_cooldown <= duration_of_global_ban then
-			local duration = math.ceil((duration_of_global_ban-tick-global_cooldown)/1000)
+			local duration = math.ceil((duration_of_global_ban-tick+global_cooldown)/1000)
 			errMsg("You are banned from using commands for " .. duration .." seconds due to continuous spam")
 			return true
 		end
 	end
 
-	if command_ddos_protection != "true" then
+	if command_ddos_protection ~= "true" then
 		return false
 	end
 

--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -8,15 +8,20 @@ g_Me = getLocalPlayer()
 server = createServerCallInterface()
 guiSetInputMode("no_binds_when_editing")
 
--- Freeroam cooldown timer for commands (miliseconds, 1000 = 1 sec):
-local frCommandCooldownTime = 2000
+-- Place to store the ticks for anti spam:
+local antiCommandSpam = {}
 
--- Place to store our cmd cooldown timers:
-local commandCDTimers = {}
-
-function cmdCDActive(cmd)
-	outputChatBox ("* Failed, don't spam the '"..tostring(cmd).."' command! *", 255, 0, 0)
+function isCommandOnCD(cmd)
+	local tick = getTickCount()
+	if antiCommandSpam[cmd] and tick-antiCommandSpam[cmd] < 2000 then
+		outputChatBox ("* Failed, don't spam the '"..tostring(cmd).."' command! *", 255, 0, 0)
+		return true
+	else
+		antiCommandSpam[cmd] = tick
+		return false
+	end
 end
+
 ---------------------------
 -- Set skin window
 ---------------------------
@@ -65,10 +70,7 @@ wndSkin = {
 }
 
 function setSkinCommand(cmd, skin)
-	if cmd then
-		if isTimer(commandCDTimers[cmd]) then cmdCDActive(cmd) return end
-		commandCDTimers[cmd] = setTimer(function()end, frCommandCooldownTime, 1)
-	end
+	if isCommandOnCD(cmd) then return end
 	skin = skin and tonumber(skin)
 	if skin then
 		server.setMySkin(skin)

--- a/[gameplay]/freeroam/fr_server.lua
+++ b/[gameplay]/freeroam/fr_server.lua
@@ -217,6 +217,7 @@ addEventHandler('onPlayerGravInit', resourceRoot,
 )
 
 function setMySkin(skinid)
+	if getElementModel(source) == skinid then return end
 	if isPedDead(source) then
 		local x, y, z = getElementPosition(source)
 		if isPedTerminated(source) then

--- a/[gameplay]/freeroam/fr_server.lua
+++ b/[gameplay]/freeroam/fr_server.lua
@@ -156,6 +156,12 @@ addEventHandler('onLoadedAtClient', g_ResRoot,
 		if getOption('spawnmaponstart') and isPedDead(client) then
 			clientCall(client, 'showWelcomeMap')
 		end
+		local settings = {}
+		settings["command_spam_protection"] = get("command_spam_protection")
+		settings["tries_required_to_trigger"] = get("tries_required_to_trigger")
+		settings["tries_required_to_trigger_low"] = get("tries_required_to_trigger_low_priority")
+		settings["command_spam_ban_duration"] = get("command_spam_ban_duration")
+		clientCall(client, 'spamProtectionSettings', settings)
 	end,
 	false
 )

--- a/[gameplay]/freeroam/meta.xml
+++ b/[gameplay]/freeroam/meta.xml
@@ -89,5 +89,29 @@
 		<setting name="*vehicles/disallowed" value="[[]]" />   <!-- Comma-separated list of vehicles that players may not create -->
 		<setting name="*chat/mainChatDelay" value="1000" />   <!-- Miliseconds between each message a player can send through main chat -->
 		<setting name="*chat/blockRepeatMessages" value="true" />   <!-- Prevent a player from saying the same thing twice in a row to spam -->
+		<setting name="@command_spam_protection" value="true"
+					friendlyname="Command Spam Protection"
+					accept="true,false"
+					group="Command Spam Protection"
+					desc="This settings enables/disables protection against command spam that can form a type of DoS-attack capable of lagging or crashing the server "
+					/>
+		<setting name="@tries_required_to_trigger" value="[5]"
+					friendlyname="Tries to trigger"
+					accept="positive number"
+					group="Command Spam Protection"
+					desc="How many tries under 2 seconds will trigger the spam protection?"
+					/>
+		<setting name="@tries_required_to_trigger_low_priority" value="[5]"
+					friendlyname="Tries to trigger - low priority"
+					accept="positive number"
+					group="Command Spam Protection"
+					desc="How many tries under 2 seconds will trigger the spam protection for low priority commands/actions such as giving ammo"
+					/>
+		<setting name="@command_spam_ban_duration" value="[10000]"
+					friendlyname="Suspend Duration"
+					accept="positive number"
+					group="Command Spam Protection"
+					desc="How many milliseconds will a global command ban last? (ignoring all calls from a spamming client)"
+					/>
 	</settings>
 </meta>


### PR DESCRIPTION
_**Note from qaisjp: please squash merge if you decide to squash merge this**_

Players can use a method to load server and cause lag by using several binds **(or macros with many binds attached at once)** to mass-trigger functions that are serverside and many expensive, this was fixed by implementing anti-command spam that cancels execution in an early stage when triggered. ~~The basic anti command spam only limits certain commands to once in 2 secs~~ (and some funcs not, like repair, flip etc to not interfere with gameplay experience that much, as they can be spammed by players for legit reasons) +

- extended detection of deliberate spam, which only triggers at inhumane trigger speeds or mashing a bind, and then applies a command use ''ban'' preventing them to use any of the commands protected by timer, for 10s

More on the attack methods: either several players using binds (or macros) in sequence with multiple server funcs in teamwork at the same moment will lag the server with as source the freeroam resource causing extensive load, they can also use macros on many binds while alone to already cause significant lag spikes. Multiple players using macro binds is even more desastrous and could time everyone out or crash the server potentially.

Server owners: if your server had lag problems and performancebrowser/IPB shows freeroam peaking in load at those moments, chances are you were hit with this misuse this **PR has now fixed.**