### PR TITLE
Admin reporting system improvements

### DIFF
--- a/[admin]/admin/client/gui/admin_inputbox.lua
+++ b/[admin]/admin/client/gui/admin_inputbox.lua
@@ -11,7 +11,7 @@
 aInputForm = nil
 local varOne, varTwo = nil, nil
 
-function aInputBox ( title, message, default, action, vOne, vTwo )
+function aInputBox ( title, message, default, action, vOne, vTwo, defaultNick, defaultReason )
 	if ( aInputForm == nil ) then
 		local x, y = guiGetScreenSize()
 		aInputForm		= guiCreateWindow ( x / 2 - 150, y / 2 - 64, 300, 170, "", false )
@@ -74,12 +74,12 @@ function aInputBox ( title, message, default, action, vOne, vTwo )
 		if not isElement(banNickEdit) then
 			banNickEdit = guiCreateEdit ( 35, 130, 60, 24, "", false, aInputForm )
 		end
-		guiSetText(banNickEdit, "Nick")
+		guiSetText(banNickEdit, defaultNick or "Nick")
 
 		if not isElement(banReasonEdit) then
 			banReasonEdit = guiCreateEdit ( 100, 130, 165, 24, "", false, aInputForm )
 		end
-		guiSetText(banReasonEdit, "Reason")
+		guiSetText(banReasonEdit, defaultReason or "Reason")
 	end
 	
 

--- a/[admin]/admin/client/gui/admin_message.lua
+++ b/[admin]/admin/client/gui/admin_message.lua
@@ -9,36 +9,78 @@
 **************************************]]
 
 aViewMessageForm = nil
+local aSuspectInfo = nil
+local viewID
 
 function aViewMessage ( id )
+	if ( aSuspectInfo and viewID and viewID ~= id ) then
+		destroyElement(aSuspectInfo)
+		aSuspectInfo = nil
+	end
+	viewID = id
 	if ( aViewMessageForm == nil ) then
 		local x, y = guiGetScreenSize()
-		aViewMessageForm	= guiCreateWindow ( x / 2 - 150, y / 2 - 125, 300, 250, "", false )
+		aViewMessageForm	= guiCreateWindow ( x / 2 - 150, y / 2 - 129, 300, 258, "", false )
 					   guiCreateLabel ( 0.05, 0.10, 0.30, 0.09, "Category:", true, aViewMessageForm )
-					   guiCreateLabel ( 0.05, 0.18, 0.30, 0.09, "Subject:", true, aViewMessageForm )
-					   guiCreateLabel ( 0.05, 0.26, 0.30, 0.09, "Time:", true, aViewMessageForm )
-					   guiCreateLabel ( 0.05, 0.34, 0.30, 0.09, "By:", true, aViewMessageForm )
+					   guiCreateLabel ( 0.05, 0.18, 0.30, 0.09, "Time:", true, aViewMessageForm )
+					   guiCreateLabel ( 0.05, 0.26, 0.30, 0.09, "By:", true, aViewMessageForm )
+		aViewMessageLabelSuspect = guiCreateLabel ( 0.05, 0.34, 0.30, 0.09, "Suspect:", true, aViewMessageForm )
+		aViewMessageSuspect	= guiCreateButton ( 0.40, 0.34, 0.55, 0.07, "View info", true, aViewMessageForm )
 		aViewMessageCategory	= guiCreateLabel ( 0.40, 0.10, 0.55, 0.09, "", true, aViewMessageForm )
-		aViewMessageSubject	= guiCreateLabel ( 0.40, 0.18, 0.55, 0.09, "", true, aViewMessageForm )
-		aViewMessageTime	= guiCreateLabel ( 0.40, 0.26, 0.55, 0.09, "", true, aViewMessageForm )
-		aViewMessageAuthor	= guiCreateLabel ( 0.40, 0.34, 0.55, 0.09, "", true, aViewMessageForm )
-		aViewMessageText	= guiCreateMemo ( 0.05, 0.41, 0.90, 0.45, "", true, aViewMessageForm )
+		aViewMessageTime	= guiCreateLabel ( 0.40, 0.18, 0.55, 0.09, "", true, aViewMessageForm )
+		aViewMessageAuthor	= guiCreateLabel ( 0.40, 0.26, 0.55, 0.09, "", true, aViewMessageForm )
+		aViewMessageText	= guiCreateMemo ( 0.05, 0.42, 0.90, 0.44, "", true, aViewMessageForm )
 					   guiMemoSetReadOnly ( aViewMessageText, true )
-		aViewMessageCloseB	= guiCreateButton ( 0.77, 0.88, 0.20, 0.09, "Close", true, aViewMessageForm )
-
+		aViewMessageCloseB	= guiCreateButton ( 0.77, 0.86, 0.20, 0.09, "Close", true, aViewMessageForm )
+		
 		addEventHandler ( "onClientGUIClick", aViewMessageForm, aClientMessageClick )
+		addEventHandler ( "onClientGUIClick", aViewMessageSuspect, aViewSuspectInfo )
+		
 		--Register With Admin Form
 		aRegister ( "Message", aViewMessageForm, aViewMessage, aViewMessageClose )
 	end
 	if ( _messages[id] ) then
 		guiSetText ( aViewMessageCategory, _messages[id].category )
-		guiSetText ( aViewMessageSubject, _messages[id].subject )
+		guiSetText ( aViewMessageForm, _messages[id].subject )
 		guiSetText ( aViewMessageTime, _messages[id].time )
 		guiSetText ( aViewMessageAuthor, _messages[id].author )
 		guiSetText ( aViewMessageText, _messages[id].text )
 		guiSetVisible ( aViewMessageForm, true )
+		if ( _messages[id].suspect ) then
+			guiSetVisible ( aViewMessageLabelSuspect, true )
+			guiSetVisible ( aViewMessageSuspect, true )
+		else
+			guiSetVisible ( aViewMessageLabelSuspect, false )
+			guiSetVisible ( aViewMessageSuspect, false )
+		end
 		guiBringToFront ( aViewMessageForm )
 		triggerServerEvent ( "aMessage", getLocalPlayer(), "read", id )
+	end
+end
+
+function aViewSuspectInfo ( button )
+	if ( button == "left" ) then
+		if ( source == aViewMessageSuspect ) then
+			if ( aSuspectInfo == nil ) then
+				local suspectInfo = _messages[viewID].suspect
+				if ( suspectInfo ) then
+					local x, y = guiGetScreenSize()
+					aSuspectInfo = guiCreateWindow(x / 2 - 145, y / 2 - 192.5, 290, 385, "Player information", false)
+					local btnClose = guiCreateButton(0.365, 0.88, 0.27, 0.10, "Close", true, aSuspectInfo)
+					addEventHandler("onClientGUIClick", btnClose, function()
+						destroyElement(aSuspectInfo)
+						aSuspectInfo = nil
+					end, false)
+
+					local infoMemo = guiCreateMemo(0.04, 0.1, 0.96, 0.75, "Nickname: "..suspectInfo.name.."\nAccount name: "..suspectInfo.username.."\nIP: "
+						..suspectInfo.ip.."\nSerial: "..suspectInfo.serial.."\nMTA version: "..suspectInfo.version.."\n\nChat log:\n"..suspectInfo.chatLog,
+					true, aSuspectInfo)
+					guiMemoSetReadOnly(infoMemo, true)
+				else
+					aMessageBox ( "error", "This report does have any suspect information." )
+				end
+			end
+		end
 	end
 end
 
@@ -46,11 +88,20 @@ function aViewMessageClose ( destroy )
 	if ( ( destroy ) or ( guiCheckBoxGetSelected ( aPerformanceMessage ) ) ) then
 		if ( aViewMessageForm ) then
 			removeEventHandler ( "onClientGUIClick", aViewMessageForm, aClientMessageClick )
+			if ( aViewMessageSuspect ) then
+				removeEventHandler ( "onClientGUIClick", aViewMessageSuspect, aViewSuspectInfo )
+			end
 			destroyElement ( aViewMessageForm )
 			aViewMessageForm = nil
+			destroyElement(aSuspectInfo)
+			aSuspectInfo = nil
 		end
 	else
 		if aViewMessageForm then guiSetVisible ( aViewMessageForm, false ) end
+		if aSuspectInfo then
+			destroyElement ( aSuspectInfo )
+			aSuspectInfo = nil
+		end
 	end
 end
 

--- a/[admin]/admin/client/gui/admin_message.lua
+++ b/[admin]/admin/client/gui/admin_message.lua
@@ -46,13 +46,9 @@ function aViewMessage ( id )
 		guiSetText ( aViewMessageAuthor, _messages[id].author )
 		guiSetText ( aViewMessageText, _messages[id].text )
 		guiSetVisible ( aViewMessageForm, true )
-		if ( _messages[id].suspect ) then
-			guiSetVisible ( aViewMessageLabelSuspect, true )
-			guiSetVisible ( aViewMessageSuspect, true )
-		else
-			guiSetVisible ( aViewMessageLabelSuspect, false )
-			guiSetVisible ( aViewMessageSuspect, false )
-		end
+		local isVisible = _messages[id].suspect ~= nil
+		guiSetVisible ( aViewMessageLabelSuspect, isVisible )
+		guiSetVisible ( aViewMessageSuspect, isVisible )
 		guiBringToFront ( aViewMessageForm )
 		triggerServerEvent ( "aMessage", getLocalPlayer(), "read", id )
 	end

--- a/[admin]/admin/client/gui/admin_messages.lua
+++ b/[admin]/admin/client/gui/admin_messages.lua
@@ -21,13 +21,17 @@ function aViewMessages ( player )
 					   guiGridListAddColumn( aMessagesList, "Subject", 0.46 )
 					   guiGridListAddColumn( aMessagesList, "Date", 0.23 )
 					   guiGridListAddColumn( aMessagesList, "Author", 0.19 )
-		aMessagesRead	= guiCreateButton ( 0.86, 0.20, 0.12, 0.09, "Read", true, aMessagesForm )
-		aMessagesDelete	= guiCreateButton ( 0.86, 0.30, 0.12, 0.09, "Delete", true, aMessagesForm )
+		aMessagesRead		= guiCreateButton ( 0.86, 0.15, 0.12, 0.09, "Read", true, aMessagesForm )
+		aMessagesDelete		= guiCreateButton ( 0.86, 0.25, 0.12, 0.09, "Delete", true, aMessagesForm )
+		aMessagesBanSerial	= guiCreateButton ( 0.86, 0.40, 0.12, 0.09, "Ban serial", true, aMessagesForm )
+		aMessagesBanIP		= guiCreateButton ( 0.86, 0.50, 0.12, 0.09, "Ban IP", true, aMessagesForm )
 		aMessagesRefresh	= guiCreateButton ( 0.86, 0.65, 0.12, 0.09, "Refresh", true, aMessagesForm )
-		aMessagesClose	= guiCreateButton ( 0.86, 0.85, 0.12, 0.09, "Close", true, aMessagesForm )
+		aMessagesClose		= guiCreateButton ( 0.86, 0.85, 0.12, 0.09, "Close", true, aMessagesForm )
 		addEventHandler ( "aMessage", _root, aMessagesSync )
 		addEventHandler ( "onClientGUIClick", aMessagesForm, aClientMessagesClick )
 		addEventHandler ( "onClientGUIDoubleClick", aMessagesForm, aClientMessagesDoubleClick )
+		guiSetEnabled( aMessagesBanSerial, false )
+		guiSetEnabled( aMessagesBanIP, false )
 		--Register With Admin Form
 		aRegister ( "Messages", aMessagesForm, aViewMessages, aViewMessagesClose )
 	end
@@ -98,6 +102,30 @@ function aClientMessagesClick ( button )
 			else
 				local id = guiGridListGetItemText ( aMessagesList, row, 1 )
 				triggerServerEvent ( "aMessage", getLocalPlayer(), "delete", tonumber ( id ) )
+			end
+		elseif ( source == aMessagesBanSerial ) then
+			aInputBox ( "Add Serial Ban", "Enter Serial to be banned", _messages[tonumber ( guiGridListGetItemText ( aMessagesList, guiGridListGetSelectedItem ( aMessagesList ), 1 ) )].suspect.serial, "banSerial" )
+		elseif ( source == aMessagesBanIP ) then
+			aInputBox ( "Add IP Ban", "Enter IP to be banned", _messages[tonumber ( guiGridListGetItemText ( aMessagesList, guiGridListGetSelectedItem ( aMessagesList ), 1 ) )].suspect.ip, "banIP" )
+		elseif ( source == aMessagesList ) then
+			local row = guiGridListGetSelectedItem ( aMessagesList )
+			if ( row == -1 ) then
+				guiSetEnabled( aMessagesBanSerial, false )
+				guiSetEnabled( aMessagesBanIP, false )
+			else
+				local id = tonumber(guiGridListGetItemText ( aMessagesList, row, 1 ))
+				local suspectInfo = _messages[id].suspect
+				if ( suspectInfo ) then
+					if ( hasPermissionTo ( "command.banserial" ) ) then
+						guiSetEnabled( aMessagesBanSerial, true )
+					end
+					if ( hasPermissionTo ( "command.banip" ) ) then
+						guiSetEnabled( aMessagesBanIP, true )
+					end
+				else
+					guiSetEnabled( aMessagesBanSerial, false )
+					guiSetEnabled( aMessagesBanIP, false )
+				end
 			end
 		end
 	end

--- a/[admin]/admin/client/gui/admin_messages.lua
+++ b/[admin]/admin/client/gui/admin_messages.lua
@@ -104,9 +104,11 @@ function aClientMessagesClick ( button )
 				triggerServerEvent ( "aMessage", getLocalPlayer(), "delete", tonumber ( id ) )
 			end
 		elseif ( source == aMessagesBanSerial ) then
-			aInputBox ( "Add Serial Ban", "Enter Serial to be banned", _messages[tonumber ( guiGridListGetItemText ( aMessagesList, guiGridListGetSelectedItem ( aMessagesList ), 1 ) )].suspect.serial, "banSerial" )
+			local data = _messages[tonumber ( guiGridListGetItemText ( aMessagesList, guiGridListGetSelectedItem ( aMessagesList ), 1 ) )]
+			aInputBox ( "Add Serial Ban", "Enter Serial to be banned", data.suspect.serial, "banSerial", _, _, data.suspect.name, data.category )
 		elseif ( source == aMessagesBanIP ) then
-			aInputBox ( "Add IP Ban", "Enter IP to be banned", _messages[tonumber ( guiGridListGetItemText ( aMessagesList, guiGridListGetSelectedItem ( aMessagesList ), 1 ) )].suspect.ip, "banIP" )
+			local data = _messages[tonumber ( guiGridListGetItemText ( aMessagesList, guiGridListGetSelectedItem ( aMessagesList ), 1 ) )]
+			aInputBox ( "Add IP Ban", "Enter IP to be banned", data.suspect.ip, "banIP", _, _, data.suspect.name, data.category )
 		elseif ( source == aMessagesList ) then
 			local row = guiGridListGetSelectedItem ( aMessagesList )
 			if ( row == -1 ) then

--- a/[admin]/admin/client/gui/admin_report.lua
+++ b/[admin]/admin/client/gui/admin_report.lua
@@ -1,4 +1,4 @@
-﻿--[[**********************************
+--[[**********************************
 *
 *	Multi Theft Auto - Admin Panel
 *
@@ -87,9 +87,14 @@ function aReportSelectPlayer ( )
 		for _, player in pairs (getElementsByType("player")) do
 			guiGridListSetItemText(playerList, guiGridListAddRow(playerList), 1, getPlayerName(player), false, false)
 		end
-		local btnSelectPlayer = guiCreateButton(0.335, 0.93, 0.33, 0.05, "Select", true, aSelectPlayer)
+		local btnSelectPlayer = guiCreateButton(0.57, 0.93, 0.33, 0.05, "Select", true, aSelectPlayer)
 		addEventHandler ( "onClientGUIClick", btnSelectPlayer, function ( )
 			guiSetText ( aReportPlayer, guiGridListGetItemText ( playerList, guiGridListGetSelectedItem ( playerList ), 1 ) )
+			destroyElement ( aSelectPlayer )
+			aSelectPlayer = nil
+		end, false )
+		local btnClose = guiCreateButton(0.10, 0.93, 0.33, 0.05, "Close", true, aSelectPlayer)
+		addEventHandler ( "onClientGUIClick", btnClose, function ( )
 			destroyElement ( aSelectPlayer )
 			aSelectPlayer = nil
 		end, false )
@@ -136,10 +141,7 @@ function aClientReportClick ( button )
 				local tableOut = {}
 				if ( guiGetVisible ( aReportPlayer ) ) then
 					local text = guiGetText ( aReportPlayer )
-					if ( text == "" ) then
-						aMessageBox ( "error", "Reported player missing." )
-						return
-					else
+					if ( text ~= "" ) then
 						tableOut.suspect = text
 					end
 				end

--- a/[admin]/admin/client/gui/admin_report.lua
+++ b/[admin]/admin/client/gui/admin_report.lua
@@ -9,29 +9,44 @@
 **************************************]]
 
 aReportForm = nil
+local reportCategories
+local aSelectPlayer = nil
 
-function aReport ( player )
+addEvent ( "onReport", true )
+function aReport ( categories )
+	if not reportCategories then
+		reportCategories = categories
+	end
 	if ( aReportForm == nil ) then
 		local x, y = guiGetScreenSize()
-		aReportForm		= guiCreateWindow ( x / 2 - 150, y / 2 - 150, 300, 300, "Contact Admin", false )
-					   guiCreateLabel ( 0.05, 0.11, 0.20, 0.09, "Category:", true, aReportForm )
-					   guiCreateLabel ( 0.05, 0.21, 0.20, 0.09, "Subject:", true, aReportForm )
-					   guiCreateLabel ( 0.05, 0.30, 0.20, 0.07, "Message:", true, aReportForm )
-		aReportCategory	= guiCreateEdit ( 0.30, 0.10, 0.65, 0.09, "Question", true, aReportForm )
+		aReportForm		= guiCreateWindow ( x / 2 - 150, y / 2 - 170, 300, 340, "Contact Admin", false )
+					   guiCreateLabel ( 0.05, 0.11, 0.20, 0.07, "Category:", true, aReportForm )
+					   guiCreateLabel ( 0.05, 0.19, 0.20, 0.07, "Subject:", true, aReportForm )
+					   guiCreateLabel ( 0.05, 0.34, 0.20, 0.07, "Message:", true, aReportForm )
+		aReportLblPlayer = guiCreateLabel ( 0.05, 0.27, 0.20, 0.07, "Player:", true, aReportForm )
+		aReportBtnPlayer = guiCreateButton ( 0.75, 0.27, 0.20, 0.07, "Select", true, aReportForm )
+		aReportCategory	= guiCreateEdit ( 0.30, 0.10, 0.65, 0.07, "Question", true, aReportForm )
 					   guiEditSetReadOnly ( aReportCategory, true )
-		aReportDropDown	= guiCreateStaticImage ( 0.86, 0.10, 0.09, 0.09, "client\\images\\dropdown.png", true, aReportForm )
+		aReportDropDown	= guiCreateStaticImage ( 0.86, 0.10, 0.09, 0.07, "client\\images\\dropdown.png", true, aReportForm )
 					   guiBringToFront ( aReportDropDown )
-		aReportCategories	= guiCreateGridList ( 0.30, 0.10, 0.65, 0.30, true, aReportForm )
+		aReportCategories	= guiCreateGridList ( 0.30, 0.10, 0.65, 0.28, true, aReportForm )
 					   guiGridListAddColumn( aReportCategories, "", 0.85 )
 					   guiSetVisible ( aReportCategories, false )
-					   guiGridListSetItemText ( aReportCategories, guiGridListAddRow ( aReportCategories ), 1, "Question", false, false )
-					   guiGridListSetItemText ( aReportCategories, guiGridListAddRow ( aReportCategories ), 1, "Suggestion", false, false )
-					   guiGridListSetItemText ( aReportCategories, guiGridListAddRow ( aReportCategories ), 1, "Cheater/Moder", false, false )
-					   guiGridListSetItemText ( aReportCategories, guiGridListAddRow ( aReportCategories ), 1, "Other", false, false )
-		aReportSubject		= guiCreateEdit ( 0.30, 0.20, 0.65, 0.09, "", true, aReportForm )
-		aReportMessage	= guiCreateMemo ( 0.05, 0.38, 0.90, 0.45, "", true, aReportForm )
+						for _, category in pairs(reportCategories) do
+							guiGridListSetItemText ( aReportCategories, guiGridListAddRow ( aReportCategories ), 1, category.subject, false, false )
+						end
+						guiSetText( aReportCategory, reportCategories[1].subject )
+		aReportSubject		= guiCreateEdit ( 0.30, 0.18, 0.65, 0.07, "", true, aReportForm )
+		aReportPlayer		= guiCreateLabel ( 0.30, 0.27, 0.50, 0.07, "", true, aReportForm )
+		aReportMessage		= guiCreateMemo ( 0.05, 0.41, 0.90, 0.42, "", true, aReportForm )
 		aReportAccept		= guiCreateButton ( 0.40, 0.88, 0.25, 0.09, "Send", true, aReportForm )
 		aReportCancel		= guiCreateButton ( 0.70, 0.88, 0.25, 0.09, "Cancel", true, aReportForm )
+		
+		if ( not reportCategories[1].playerReport ) then
+			guiSetVisible ( aReportPlayer, false )
+			guiSetVisible ( aReportLblPlayer, false )
+			guiSetVisible ( aReportBtnPlayer, false )
+		end
 
 		addEventHandler ( "onClientGUIClick", aReportForm, aClientReportClick )
 		addEventHandler ( "onClientGUIDoubleClick", aReportForm, aClientReportDoubleClick )
@@ -39,7 +54,8 @@ function aReport ( player )
 	guiBringToFront ( aReportForm )
 	showCursor ( true )
 end
-addCommandHandler ( "report", aReport )
+addEventHandler( "onReport", localPlayer, aReport )
+
 
 function aReportClose ( )
 	if ( aReportForm ) then
@@ -51,12 +67,54 @@ function aReportClose ( )
 	end
 end
 
+function aReportSelectPlayer ( )
+	if ( aSelectPlayer == nil ) then
+		local x, y = guiGetScreenSize ( )
+		aSelectPlayer = guiCreateWindow ( x / 2 - 155, y / 2 - 250, 310, 500, "Select player", false)
+		local playerList = guiCreateGridList(0.03, 0.06, 0.97, 0.78, true, aSelectPlayer)
+		local searchBox = guiCreateEdit(0.115, 0.86, 0.77, 0.06, "", true, aSelectPlayer)
+		addEventHandler ( "onClientGUIChanged", searchBox, function ( )
+			guiGridListClear ( playerList )
+			local text = guiGetText ( source )
+			for _, player in pairs ( getElementsByType ( "player" ) ) do
+				local playerName = getPlayerName ( player )
+				if ( string.find ( string.upper ( playerName ), string.upper ( text ), 1, true ) ) then
+					guiGridListSetItemText ( playerList, guiGridListAddRow ( playerList ), 1, playerName, false, false )
+				end
+			end
+		end )
+		guiGridListAddColumn ( playerList, "Player name", 0.85 )
+		for _, player in pairs (getElementsByType("player")) do
+			guiGridListSetItemText(playerList, guiGridListAddRow(playerList), 1, getPlayerName(player), false, false)
+		end
+		local btnSelectPlayer = guiCreateButton(0.335, 0.93, 0.33, 0.05, "Select", true, aSelectPlayer)
+		addEventHandler ( "onClientGUIClick", btnSelectPlayer, function ( )
+			guiSetText ( aReportPlayer, guiGridListGetItemText ( playerList, guiGridListGetSelectedItem ( playerList ), 1 ) )
+			destroyElement ( aSelectPlayer )
+			aSelectPlayer = nil
+		end, false )
+	end
+end
+
 function aClientReportDoubleClick ( button )
 	if ( button == "left" ) then
 		if ( source == aReportCategories ) then
 			if ( guiGridListGetSelectedItem ( aReportCategories ) ~= -1 ) then
 				local cat = guiGridListGetItemText ( aReportCategories, guiGridListGetSelectedItem ( aReportCategories ), 1 )
 				guiSetText ( aReportCategory, cat )
+				for _, category in pairs(reportCategories) do
+					if ( category.subject == cat ) then
+						if ( category.playerReport ) then
+							guiSetVisible ( aReportPlayer, true )
+							guiSetVisible ( aReportLblPlayer, true )
+							guiSetVisible ( aReportBtnPlayer, true )
+						else
+							guiSetVisible ( aReportPlayer, false )
+							guiSetVisible ( aReportLblPlayer, false )
+							guiSetVisible ( aReportBtnPlayer, false )
+						end
+					end
+				end
 				guiSetVisible ( aReportCategories, false )
 			end
 		end
@@ -75,9 +133,18 @@ function aClientReportClick ( button )
 			if ( ( string.len ( guiGetText ( aReportSubject ) ) < 1 ) or ( string.len ( guiGetText ( aReportMessage ) ) < 5 ) ) then
 				aMessageBox ( "error", "Subject/Message missing." )
 			else
-				aMessageBox ( "info", "Your message has been submited and will be processed as soon as possible." )
-				setTimer ( aMessageBoxClose, 3000, 1, true )
 				local tableOut = {}
+				if ( guiGetVisible ( aReportPlayer ) ) then
+					local text = guiGetText ( aReportPlayer )
+					if ( text == "" ) then
+						aMessageBox ( "error", "Reported player missing." )
+						return
+					else
+						tableOut.suspect = text
+					end
+				end
+				aMessageBox ( "info", "Your message has been submitted and will be processed as soon as possible." )
+				setTimer ( aMessageBoxClose, 3000, 1, true )
 				tableOut.category = guiGetText ( aReportCategory )
 				tableOut.subject = guiGetText ( aReportSubject )
 				tableOut.message = guiGetText ( aReportMessage )
@@ -93,6 +160,8 @@ function aClientReportClick ( button )
 		elseif ( source == aReportDropDown ) then
 			guiBringToFront ( aReportCategories )
 			guiSetVisible ( aReportCategories, true )
+		elseif ( source == aReportBtnPlayer ) then
+			aReportSelectPlayer ( )
 		end
 	end
 end

--- a/[admin]/admin/client/gui/admin_report.lua
+++ b/[admin]/admin/client/gui/admin_report.lua
@@ -12,12 +12,16 @@ aReportForm = nil
 local reportCategories
 local aSelectPlayer = nil
 
-addEvent ( "onReport", true )
-function aReport ( categories )
-	if not reportCategories then
-		reportCategories = categories
-	end
+function aReport ( )
 	if ( aReportForm == nil ) then
+		reportCategories = {}
+		for i,cat in ipairs( split( g_Prefs.reportCategories, string.byte(',') ) ) do
+			table.insert ( reportCategories, { subject = cat } )
+		end
+		for i,cat in ipairs( split( g_Prefs.playerReportCategories, string.byte(',') ) ) do
+			table.insert ( reportCategories, { subject = cat, playerReport = true } )
+		end
+		
 		local x, y = guiGetScreenSize()
 		aReportForm		= guiCreateWindow ( x / 2 - 150, y / 2 - 170, 300, 340, "Contact Admin", false )
 					   guiCreateLabel ( 0.05, 0.11, 0.20, 0.07, "Category:", true, aReportForm )
@@ -32,15 +36,15 @@ function aReport ( categories )
 		aReportCategories	= guiCreateGridList ( 0.30, 0.10, 0.65, 0.28, true, aReportForm )
 					   guiGridListAddColumn( aReportCategories, "", 0.85 )
 					   guiSetVisible ( aReportCategories, false )
-						for _, category in pairs(reportCategories) do
-							guiGridListSetItemText ( aReportCategories, guiGridListAddRow ( aReportCategories ), 1, category.subject, false, false )
+						for a=1, #reportCategories do
+							guiGridListSetItemText ( aReportCategories, guiGridListAddRow ( aReportCategories ), 1, reportCategories[a].subject, false, false )
 						end
 						guiSetText( aReportCategory, reportCategories[1].subject )
-		aReportSubject		= guiCreateEdit ( 0.30, 0.18, 0.65, 0.07, "", true, aReportForm )
-		aReportPlayer		= guiCreateLabel ( 0.30, 0.27, 0.50, 0.07, "", true, aReportForm )
-		aReportMessage		= guiCreateMemo ( 0.05, 0.41, 0.90, 0.42, "", true, aReportForm )
-		aReportAccept		= guiCreateButton ( 0.40, 0.88, 0.25, 0.09, "Send", true, aReportForm )
-		aReportCancel		= guiCreateButton ( 0.70, 0.88, 0.25, 0.09, "Cancel", true, aReportForm )
+		aReportSubject	= guiCreateEdit ( 0.30, 0.18, 0.65, 0.07, "", true, aReportForm )
+		aReportPlayer	= guiCreateLabel ( 0.30, 0.27, 0.50, 0.07, "", true, aReportForm )
+		aReportMessage	= guiCreateMemo ( 0.05, 0.41, 0.90, 0.42, "", true, aReportForm )
+		aReportAccept	= guiCreateButton ( 0.40, 0.88, 0.25, 0.09, "Send", true, aReportForm )
+		aReportCancel	= guiCreateButton ( 0.70, 0.88, 0.25, 0.09, "Cancel", true, aReportForm )
 		
 		if ( not reportCategories[1].playerReport ) then
 			guiSetVisible ( aReportPlayer, false )
@@ -54,7 +58,7 @@ function aReport ( categories )
 	guiBringToFront ( aReportForm )
 	showCursor ( true )
 end
-addEventHandler( "onReport", localPlayer, aReport )
+addCommandHandler ( "report", aReport )
 
 
 function aReportClose ( )
@@ -107,9 +111,9 @@ function aClientReportDoubleClick ( button )
 			if ( guiGridListGetSelectedItem ( aReportCategories ) ~= -1 ) then
 				local cat = guiGridListGetItemText ( aReportCategories, guiGridListGetSelectedItem ( aReportCategories ), 1 )
 				guiSetText ( aReportCategory, cat )
-				for _, category in pairs(reportCategories) do
-					if ( category.subject == cat ) then
-						if ( category.playerReport ) then
+				for i=1, #reportCategories do
+					if ( reportCategories[i].subject == cat ) then
+						if ( reportCategories[i].playerReport ) then
 							guiSetVisible ( aReportPlayer, true )
 							guiSetVisible ( aReportLblPlayer, true )
 							guiSetVisible ( aReportBtnPlayer, true )

--- a/[admin]/admin/conf/reports.xml
+++ b/[admin]/admin/conf/reports.xml
@@ -2,7 +2,7 @@
     <categories>
         <category isPlayerReport="false">Question</category>
         <category isPlayerReport="false">Suggestion</category>
-        <category isPlayerReport="true">Cheater/Moder</category>
+        <category isPlayerReport="true">Cheater/Modder</category>
         <category isPlayerReport="false">Other</category>
     </categories>
 </messages>

--- a/[admin]/admin/conf/reports.xml
+++ b/[admin]/admin/conf/reports.xml
@@ -1,8 +1,0 @@
-<messages>
-    <categories>
-        <category isPlayerReport="false">Question</category>
-        <category isPlayerReport="false">Suggestion</category>
-        <category isPlayerReport="true">Cheater/Modder</category>
-        <category isPlayerReport="false">Other</category>
-    </categories>
-</messages>

--- a/[admin]/admin/conf/reports.xml
+++ b/[admin]/admin/conf/reports.xml
@@ -1,0 +1,8 @@
+<messages>
+    <categories>
+        <category isPlayerReport="false">Question</category>
+        <category isPlayerReport="false">Suggestion</category>
+        <category isPlayerReport="true">Cheater/Moder</category>
+        <category isPlayerReport="false">Other</category>
+    </categories>
+</messages>

--- a/[admin]/admin/meta.xml
+++ b/[admin]/admin/meta.xml
@@ -337,9 +337,19 @@
 					/>
 					
 		<setting name="*maxchatmsgs" value="10"
-					friendlyname="Max chat log messages."
+					friendlyname="Max chat log messages"
 					accept="1-1000"
 					desc="Maximum chat log messages per player to store. Decreasing this value may save some of server RAM."
+					/>
+					
+		<setting name="*reportCategories" value="Question,Suggestion,Other"
+					friendlyname="Report categories"
+					desc="List of non player report categories."
+					/>
+
+		<setting name="*playerReportCategories" value="Cheater/Modder,Spammer"
+					friendlyname="Player report categories"
+					desc="List of report categories for reporting players."
 					/>
 
  </settings>

--- a/[admin]/admin/meta.xml
+++ b/[admin]/admin/meta.xml
@@ -335,6 +335,13 @@
 					accept="500-60000"
 					desc="Time in miliseconds between a player being able to change their name to prevent nick change spam"
 					/>
+					
+		<setting name="*maxchatmsgs" value="10"
+					friendlyname="Max chat log messages."
+					accept="1-1000"
+					desc="Maximum chat log messages per player to store. Decreasing this value may save some of server RAM."
+					/>
+
  </settings>
 
 </meta>

--- a/[admin]/admin/server/admin_server.lua
+++ b/[admin]/admin/server/admin_server.lua
@@ -1375,7 +1375,6 @@ addEventHandler ( "onPlayerChat", root, function ( message )
 	if ( size == g_Prefs.maxchatmsgs ) then
 		table.remove( chatHistory[source], 1 )
 		size = size - 1
-		outputChatBox("removed")
 	end
 	chatHistory[source][size + 1] = message
 end )

--- a/[admin]/admin/server/admin_server.lua
+++ b/[admin]/admin/server/admin_server.lua
@@ -173,7 +173,7 @@ addEventHandler ( "onResourceStart", _root, function ( resource )
 				aReportCategories[i].subject = xmlNodeGetValue ( child )
 			end
 		end
-	xmlUnloadFile ( node )
+		xmlUnloadFile ( node )
 	end
 		
 	local node = xmlLoadFile ( "conf\\messages.xml" )

--- a/[admin]/admin/server/admin_serverprefs.lua
+++ b/[admin]/admin/server/admin_serverprefs.lua
@@ -16,9 +16,11 @@ function cachePrefs()
 	g_Prefs.maxmsgs		= getNumber('maxmsgs',99)
 	g_Prefs.bandurations	= getString('bandurations','60,3600,43200,0')
 	g_Prefs.mutedurations	= getString('mutedurations','60,120,300,600,0')
+	g_Prefs.reportCategories = getString('reportCategories','Question,Suggestion,Other')
+	g_Prefs.playerReportCategories = getString('playerReportCategories','Cheater/Modder,Spammer')
 	g_Prefs.clientcheckban	= getBool('clientcheckban',false)
 	g_Prefs.securitylevel	= getNumber('securitylevel',2)
-	g_Prefs.maxchatmsgs 	= getNumber('maxchatmsgs',2)
+	g_Prefs.maxchatmsgs 	= getNumber('maxchatmsgs',10)
 	triggerClientEvent( root, "onClientUpdatePrefs", resourceRoot, g_Prefs )
 end
 

--- a/[admin]/admin/server/admin_serverprefs.lua
+++ b/[admin]/admin/server/admin_serverprefs.lua
@@ -13,11 +13,12 @@
 ---------------------------------------------------------------------------
 function cachePrefs()
 	g_Prefs = {}
-	g_Prefs.maxmsgs			= getNumber('maxmsgs',99)
+	g_Prefs.maxmsgs		= getNumber('maxmsgs',99)
 	g_Prefs.bandurations	= getString('bandurations','60,3600,43200,0')
 	g_Prefs.mutedurations	= getString('mutedurations','60,120,300,600,0')
 	g_Prefs.clientcheckban	= getBool('clientcheckban',false)
 	g_Prefs.securitylevel	= getNumber('securitylevel',2)
+	g_Prefs.maxchatmsgs 	= getNumber('maxchatmsgs',2)
 	triggerClientEvent( root, "onClientUpdatePrefs", resourceRoot, g_Prefs )
 end
 


### PR DESCRIPTION
Added report category settings to reports.xml configuration. This will allow server owners to configure the report categories.

Added player report functionality. Each report category in reports.xml has an attribute called "isPlayerReport". If set to true, when reporting, the player will be asked to select the player that he wants to report. Admins will later be able to easily review the suspected player's information such as IP address, serial, MTA version, name and chat log.

Added Ban serial and Ban IP buttons in messages viewer. These buttons will only be enabled for report categories that have isPlayerReport set to true.
When clicked, a ban input box will appear with serial or IP automatically filled according to the report information. This will allow admins to save extra time, especially when banning offline players.

Added logging for deleting reports.

Added chat log storage. Admin resource will collect and store most recent chat messages. There is a limit setting in meta.xml which by default is 10 messages per player.
Chat logging is especially useful for reports. For example if a report category "Cursing" is added, regular staff members will be able to see the recent chat log since they do not usually have access to server.log
