### PR TITLE
Some bugfixes (+ #64)

### DIFF
--- a/[gameplay]/realdriveby/driveby_client.lua
+++ b/[gameplay]/realdriveby/driveby_client.lua
@@ -97,7 +97,15 @@ addEventHandler("doSendDriveBySettings",localPlayer, function ( newSettings, the
 		peds[i] = v 
 		pedowner[v] = i
 	end
-end )
+	if eject_on_driveby_fix then
+		--[[ Block driveby when exiting vehicle: 
+  		setPedDoingGangDriveby ejects the player if he is trying to get out of the vehicle (without animations ) ]]
+		addEventHandler ( "onClientVehicleStartExit", root, function ( player )
+		if player == localPlayer then
+			exitingvehicle = true
+		end
+	end
+end )	
 
 
 -- Use driveby --
@@ -296,15 +304,6 @@ functions.toggleTurningKeys = function(vehicleID, state)
 	end
 end
 
-
---[[ Block driveby when exiting vehicle: 
-  setPedDoingGangDriveby ejects the player if he is trying to get out of the vehicle (without animations ) ]]
-addEventHandler ( "onClientVehicleStartExit", root, function ( player )
-	if player == localPlayer then
-		exitingvehicle = true
-	end
-end )
-	
 
 --This function simply sets up the driveby upon vehicle entry
 addEventHandler( "onClientPlayerVehicleEnter", localPlayer, function ( _, seat )

--- a/[gameplay]/realdriveby/driveby_client.lua
+++ b/[gameplay]/realdriveby/driveby_client.lua
@@ -1,295 +1,373 @@
-﻿local driver = false
+addEvent ( "doSendDriveBySettings", true )
+addEvent ( "deletePedForDrivebyFix", true )
+addEvent ( "savePedForDrivebyFix", true )
+
+---Left/right toggling
+local bikes = { [581]=true,[509]=true,[481]=true,[462]=true,[521]=true,[463]=true,
+	[510]=true,[522]=true,[461]=true,[448]=true,[468]=true,[586]=true }
+local driver = false
 local shooting = false
-local helpText,helpAnimation
-lastSlot = 0
-settings = {}
+local exitingvehicle = false 
+local helpText, helpAnimation, block
+local lastSlot = 0
+local settings = {}
+local functions = {}  -- using this table to easily localize functions
+local limiterTimer
+local peds = {}
+local pedowner = {}
 
 
---This function simply sets up the driveby upon vehicle entry
-local function setupDriveby( player, seat )
-	--If his seat is 0, store the fact that he's a driver
-	if seat == 0 then 
-		driver = true
-	else
-		driver = false
-	end
-	--By default, we set the player's equiped weapon to nothing.
-	setPedWeaponSlot( localPlayer, 0 )
-	if settings.autoEquip then
-		toggleDriveby()
+-- Use this to detect damage on the player using driveby on a bike --
+local function pedGotHit ( attacker, weapon, bodypart, loss )
+	-- Let the attacker trigger it --
+	if attacker == localPlayer and pedowner[source] ~= attacker then
+		triggerEvent ( "onClientPlayerDamage", pedowner[source], attacker, weapon, bodypart, loss )
 	end
 end
-addEventHandler( "onClientPlayerVehicleEnter", localPlayer, setupDriveby )
 
---Tell the server the clientside script was downloaded and started
-addEventHandler("onClientResourceStart",getResourceRootElement(getThisResource()),
-	function()
-		bindKey ( "mouse2", "down", "Toggle Driveby", "" )
-		bindKey ( "e", "down", "Next driveby weapon", "1" )
-		bindKey ( "q", "down", "Previous driveby weapon", "-1" )
-		toggleControl ( "vehicle_next_weapon",false )
-		toggleControl ( "vehicle_previous_weapon",false )
-		triggerServerEvent ( "driveby_clientScriptLoaded", localPlayer )
-		helpText = dxText:create("",0.5,0.85)
-		helpText:scale(1)
-		helpText:type("stroke",1)
-	end
-)
 
-addEventHandler("onClientResourceStop",getResourceRootElement(getThisResource()),
-	function()
-		toggleControl ( "vehicle_next_weapon",true )
-		toggleControl ( "vehicle_previous_weapon",true )
+-- function to change the alpha of the helptext --
+local function helpTextChangeAlpha ( alpha )
+	helpText:color(255,255,255,alpha)
+end
+
+
+-- fade in help --
+local function fadeInHelp ()
+	if helpAnimation then helpAnimation:remove() end
+	local _,_,_,a = helpText:color()
+	if a ~= 255 then
+		helpAnimation = Animation.createAndPlay(helpText, Animation.presets.dxTextFadeIn(300))
+		setTimer ( helpTextChangeAlpha, 300, 1, 255 )
 	end
-)
+end
+
+
+-- fade out help --
+local function fadeOutHelp ()
+	if helpAnimation then helpAnimation:remove() end
+	local _,_,_,a = helpText:color()
+	if a ~= 0 then
+		helpAnimation = Animation.createAndPlay(helpText, Animation.presets.dxTextFadeOut(300))
+		setTimer ( helpTextChangeAlpha, 300, 1, 0 )
+	end
+end
+
+
+-- remove keys for using driveby --
+functions.removeKeyToggles = function ( vehicle )
+	toggleControl ( "vehicle_look_left",true )
+	toggleControl ( "vehicle_look_right",true )
+	toggleControl ( "vehicle_secondary_fire",true )
+	functions.toggleTurningKeys(getElementModel(vehicle),true)
+	fadeOutHelp()
+	removeEventHandler ( "onClientPlayerVehicleExit", localPlayer, functions.removeKeyToggles )
+end
+
 
 --Get the settings details from the server, and act appropriately according to them
-addEvent ( "doSendDriveBySettings", true )
-addEventHandler("doSendDriveBySettings",localPlayer,
-	function(newSettings)
-		settings = newSettings
-		--We change the blocked vehicles into an indexed table that's easier to check
-		local newTable = {}
-		for key,vehicleID in ipairs(settings.blockedVehicles) do
-			newTable[vehicleID] = true
+addEventHandler("doSendDriveBySettings",localPlayer, function ( newSettings, thepeds )
+	settings = newSettings
+	--We change the tables into an indexed table that's easier to check
+	local newTable = {}
+	if settings.blockedVehicles[1] then
+		for i=1, #settings.blockedVehicles do
+			newTable[settings.blockedVehicles[i]] = true
 		end
-		settings.blockedVehicles = newTable
 	end
-)
+	settings.blockedVehicles = newTable
+	newTable = {}
+	if settings.driver[1] then
+		for i=1, #settings.driver do 
+			newTable[settings.driver[i]] = true
+		end
+	end
+	settings.driver = newTable
+	-- get the peds of the guys using driveby --
+	newTable = {}
+	if settings.passenger[1] then
+		for i=1, #settings.passenger do 
+			newTable[settings.passenger[i]] = true
+		end
+	end
+	settings.passenger = newTable
+	peds = {}
+	pedowner = {}
+	for i, v in pairs ( thepeds ) do
+		peds[i] = v 
+		pedowner[v] = i
+	end
+end )
 
---This function handles the driveby toggling key.
-function toggleDriveby()
-	--If he's not in a vehicle dont bother
-	if not isPedInVehicle( localPlayer ) then return end
-	--If its a blocked vehicle dont allow it
-	local vehicleID = getElementModel ( getPedOccupiedVehicle ( localPlayer ) )
-	if settings.blockedVehicles[vehicleID] then return end
-	--Has he got a weapon equiped?
-	local equipedWeapon = getPedWeaponSlot( localPlayer )
-	if equipedWeapon == 0 then
-		--Decide whether he is a driver or passenger
-		if ( driver ) then weaponsTable = settings.driver
-		else weaponsTable = settings.passenger end
-		--We need to get the switchTo weapon by finding any valid IDs
-		local switchTo
-		local switchToWeapon
-		local lastSlotAmmo = getPedTotalAmmo ( localPlayer, lastSlot )
-		if not lastSlotAmmo or lastSlotAmmo == 0 or getSlotFromWeapon(getPedWeapon (localPlayer,lastSlot)) == 0 then
-			for key,weaponID in ipairs(weaponsTable) do
-				local slot = getSlotFromWeapon ( weaponID )
-				local weapon = getPedWeapon ( localPlayer, slot )
-				if weapon == 1 then weapon = 0 end --If its a brass knuckle, set it to a fist to avoid confusion
-				--if the weapon the player has is valid
-				if weapon == weaponID then
-					--If the ammo isn't 0
-					if getPedTotalAmmo ( localPlayer, slot ) ~= 0 then
-						--If no switchTo slot was defined, or the slot was 4 (SMG slot takes priority)
-						if not switchTo or slot == 4 then
-							switchTo = slot
-							switchToWeapon = weaponID
+
+-- Use driveby --
+functions.toggleDriveby = function()
+	-- if you are in a vehicle --
+	if isPedInVehicle ( localPlayer ) then
+		local veh = getPedOccupiedVehicle ( localPlayer )
+		local vehicleID = getElementModel ( veh )
+		-- if the vehicle isn't blocked for using driveby --
+		if not settings.blockedVehicles[vehicleID] then
+			local equipedWeapon = getPedWeaponSlot ( localPlayer )
+			-- if you dont have any equiped weapons (not doing driveby) --
+			if equipedWeapon == 0 then
+				-- if the player isn't exiting the vehicle --
+	 			if not exitingvehicle then
+					local weaponsTable = driver and settings.driver or settings.passenger
+					local switchTo
+					local switchToWeapon
+					local lastSlotAmmo = getPedTotalAmmo ( localPlayer, lastSlot )
+					local lastSlotWeapon = getPedWeapon ( localPlayer, lastSlot )
+					-- if you didn't used a weapon last time or don't have ammo for it, get a new weapon --
+					if ( not lastSlotAmmo or lastSlotAmmo == 0 or lastSlot == 0 ) and not weaponsTable[lastSlotWeapon] then
+						for i=1, 12 do
+							local weapon = getPedWeapon ( localPlayer, i )
+							if weaponsTable[( weapon == 1 and 0 or weapon )] then
+								if getPedTotalAmmo ( localPlayer, i ) ~= 0 then
+									if not switchTo or i == 4 then
+										switchTo = i
+										switchToWeapon = weapon
+										break
+									end
+								end
+							end
+						end
+					else 
+						switchTo = lastSlot
+						switchToWeapon = lastSlotWeapon
+					end
+					-- if you got a weapon to switch to --
+					if switchTo then
+						setPedDoingGangDriveby ( localPlayer, true )
+						setPedWeaponSlot( localPlayer, switchTo )
+						functions.limitDrivebySpeed ( switchToWeapon )
+						toggleControl ( "vehicle_look_left",false )
+						toggleControl ( "vehicle_look_right",false )
+						toggleControl ( "vehicle_secondary_fire",false )
+						functions.toggleTurningKeys(vehicleID,false)
+						if settings.bikeHitboxFix and getVehicleType ( veh ) == "Bike" then
+							triggerServerEvent ( "createPedForDrivebyFix", localPlayer )
+						end
+						addEventHandler ( "onClientPlayerVehicleExit",localPlayer,functions.removeKeyToggles )
+						local prevw,nextw = next(getBoundKeys ( "Previous driveby weapon" )),next(getBoundKeys ( "Next driveby weapon" ))
+						if prevw and nextw then
+							if animation then 
+								Animation:remove() 
+							end
+							helpText:text( "Press '"..prevw.."' or '"..nextw.."' to change weapon" )
+							fadeInHelp()
+							setTimer ( fadeOutHelp, 10000, 1 )
+						end
+					end
+				end
+			else -- if you are already in driveby
+				setPedDoingGangDriveby ( localPlayer, false )
+				setPedWeaponSlot( localPlayer, 0 )
+				functions.limitDrivebySpeed ( switchToWeapon )
+				toggleControl ( "vehicle_look_left",true )
+				toggleControl ( "vehicle_look_right",true )
+				toggleControl ( "vehicle_secondary_fire",true )
+				functions.toggleTurningKeys(vehicleID,true)
+				fadeOutHelp()
+				triggerServerEvent ( "destroyPedForDrivebyFix", localPlayer )
+				removeEventHandler ( "onClientPlayerVehicleExit",localPlayer,functions.removeKeyToggles )
+			end
+		end
+	end
+end
+addCommandHandler ( "Toggle Driveby", functions.toggleDriveby )
+
+
+
+--This function handles the driveby switch weapon key
+functions.switchDrivebyWeapon = function(cmd,progress)
+	if not block then
+		-- progress = -1 (previous weapon) or 1 (next weapon)
+		progress = tonumber(progress)
+		if progress then
+			if not shooting then
+				if isPedInVehicle( localPlayer ) then
+					local currentWeapon = getPedWeapon( localPlayer )
+					local currentSlot = getPedWeaponSlot(localPlayer)
+					if currentSlot ~= 0 then
+						local weaponsTable = driver and settings.driver or settings.passenger
+						local switchTo, switchToWeapon
+						if not weaponsTable[currentWeapon] then
+							switchToWeapon = 0
+							switchTo = 0
+						end
+						local j = currentSlot + progress
+						while j ~= currentSlot do
+							local nextWeapon = getPedWeapon ( localPlayer, j )
+							if nextWeapon and weaponsTable[nextWeapon] then
+								switchToWeapon = nextWeapon
+								switchTo = j
+								break
+							end
+							if j + progress < 0 or j + progress > 12 then
+								j = progress < 0 and 12 or 1
+							else
+								j = j + progress
+							end
+						end
+						--If a valid weapon was not found, dont set anything.
+						if switchTo then
+							lastSlot = switchTo
+							setPedWeaponSlot( localPlayer, switchTo )
+							functions.limitDrivebySpeed ( switchToWeapon )
 						end
 					end
 				end
 			end
-		else
-			local lastSlotWeapon = getPedWeapon ( localPlayer, lastSlot )
-			for key,weaponID in ipairs(weaponsTable) do --If our last used weapon is a valid weapon
-				if weaponID == lastSlotWeapon then
-					switchTo = lastSlot
-					switchToWeapon = lastSlotWeapon
-					break
-				end
-			end
-		end
-		--If a valid weapon was not found, dont set anything.
-		if not switchTo then return end
-		setPedDoingGangDriveby ( localPlayer, true )
-		setPedWeaponSlot( localPlayer, switchTo )
-		--Setup our driveby limiter
-		limitDrivebySpeed ( switchToWeapon )
-		--Disable look left/right keys, they seem to become accelerate/decelerate (carried over from PS2 version)
-		toggleControl ( "vehicle_look_left",false )
-		toggleControl ( "vehicle_look_right",false )
-		toggleControl ( "vehicle_secondary_fire",false )
-		toggleTurningKeys(vehicleID,false)
-		addEventHandler ( "onClientPlayerVehicleExit",localPlayer,removeKeyToggles )
-		local prevw,nextw = next(getBoundKeys ( "Previous driveby weapon" )),next(getBoundKeys ( "Next driveby weapon" ))
-		if prevw and nextw then
-			if animation then Animation:remove() end
-			helpText:text( "Press '"..prevw.."' or '"..nextw.."' to change weapon" )
-			fadeInHelp()
-			setTimer ( fadeOutHelp, 10000, 1 )
-		end
-	else
-		--If so, unequip it
-		setPedDoingGangDriveby ( localPlayer, false )
-		setPedWeaponSlot( localPlayer, 0 )
-		limitDrivebySpeed ( switchToWeapon )
-		toggleControl ( "vehicle_look_left",true )
-		toggleControl ( "vehicle_look_right",true )
-		toggleControl ( "vehicle_secondary_fire",true )
-		toggleTurningKeys(vehicleID,true)
-		fadeOutHelp()
-		removeEventHandler ( "onClientPlayerVehicleExit",localPlayer,removeKeyToggles )
-	end
-end
-addCommandHandler ( "Toggle Driveby", toggleDriveby )
-
-function removeKeyToggles(vehicle)
-	toggleControl ( "vehicle_look_left",true )
-	toggleControl ( "vehicle_look_right",true )
-	toggleControl ( "vehicle_secondary_fire",true )
-	toggleTurningKeys(getElementModel(vehicle),true)
-	fadeOutHelp()
-	removeEventHandler ( "onClientPlayerVehicleExit",localPlayer,removeKeyToggles )
-end
-
-
---This function handles the driveby switch weapon key
-function switchDrivebyWeapon(key,progress)
-	progress = tonumber(progress)
-	if not progress then return end
-	--If the fire button is being pressed dont switch
-	if shooting then return end
-	--If he's not in a vehicle dont bother
-	if not isPedInVehicle( localPlayer ) then return end
-	--If he's not in driveby mode dont bother either
-	local currentWeapon = getPedWeapon( localPlayer )
-	if currentWeapon == 1 then currentWeapon = 0 end --If its a brass knuckle, set it to a fist to avoid confusion
-	local currentSlot = getPedWeaponSlot(localPlayer)
-	if currentSlot == 0 then return end
-	if ( driver ) then weaponsTable = settings.driver
-	else weaponsTable = settings.passenger end
-	--Compile a list of the player's weapons
-	local switchTo
-	for key,weaponID in ipairs(weaponsTable) do
-		if weaponID == currentWeapon then
-			local i = key + progress
-			--We keep looping the table until we go back to our original key
-			while i ~= key do
-				nextWeapon = weaponsTable[i]
-				if nextWeapon then
-					local slot = getSlotFromWeapon ( nextWeapon )
-					local weapon = getPedWeapon ( localPlayer, slot )
-					if ( weapon == nextWeapon  ) then
-						switchToWeapon = weapon
-						switchTo = slot
-						break
-					end
-				end
-				--Go back to the beginning if there is no valid weapons left in the table
-				if not weaponsTable[i+progress] then
-					if progress < 0 then
-						i = #weaponsTable
-					else
-						i = 1
-					end
-				else
-					i = i + progress
-				end
-			end
-			break
 		end
 	end
-	--If a valid weapon was not found, dont set anything.
-	if not switchTo then return end
-	lastSlot = switchTo
-	setPedWeaponSlot( localPlayer, switchTo )
-	limitDrivebySpeed ( switchToWeapon )
 end
-addCommandHandler ( "Next driveby weapon", switchDrivebyWeapon )
-addCommandHandler ( "Previous driveby weapon", switchDrivebyWeapon )
+addCommandHandler ( "Next driveby weapon", functions.switchDrivebyWeapon )
+addCommandHandler ( "Previous driveby weapon", functions.switchDrivebyWeapon )
+
 
 --Here lies the stuff that limits shooting speed (so slow weapons dont shoot ridiculously fast)
-local limiterTimer
-function limitDrivebySpeed ( weaponID )
+functions.limitDrivebySpeed = function( weaponID )
 	local speed = settings.shotdelay[tostring(weaponID)]
 	if not speed then 
 		if not isControlEnabled ( "vehicle_fire" ) then 
 			toggleControl ( "vehicle_fire", true )
 		end
-		removeEventHandler("onClientPlayerVehicleExit",localPlayer,unbindFire)
-		removeEventHandler("onClientPlayerWasted",localPlayer,unbindFire)
-		unbindKey ( "vehicle_fire", "both", limitedKeyPress )
-	else
-		if isControlEnabled ( "vehicle_fire" ) then 
-			toggleControl ( "vehicle_fire", false )
-			addEventHandler("onClientPlayerVehicleExit",localPlayer,unbindFire)
-			addEventHandler("onClientPlayerWasted",localPlayer,unbindFire)
-			bindKey ( "vehicle_fire","both",limitedKeyPress,speed)
-		end
+		removeEventHandler("onClientPlayerVehicleExit",localPlayer,functions.unbindFire)
+		removeEventHandler("onClientPlayerWasted",localPlayer,functions.unbindFire)
+		unbindKey ( "vehicle_fire", "both", functions.limitedKeyPress )
+	elseif isControlEnabled ( "vehicle_fire" ) then 
+		toggleControl ( "vehicle_fire", false )
+		addEventHandler("onClientPlayerVehicleExit",localPlayer,functions.unbindFire)
+		addEventHandler("onClientPlayerWasted",localPlayer,functions.unbindFire)
+		bindKey ( "vehicle_fire","both",functions.limitedKeyPress,speed)
 	end
 end
 
-function unbindFire()
-	unbindKey ( "vehicle_fire", "both", limitedKeyPress )
+
+functions.unbindFire = function()
+	unbindKey ( "vehicle_fire", "both", functions.limitedKeyPress )
 	if not isControlEnabled ( "vehicle_fire" ) then 
-			toggleControl ( "vehicle_fire", true )
+		toggleControl ( "vehicle_fire", true )
 	end
-	removeEventHandler("onClientPlayerVehicleExit",localPlayer,unbindFire)
-	removeEventHandler("onClientPlayerWasted",localPlayer,unbindFire)
+	removeEventHandler("onClientPlayerVehicleExit",localPlayer,functions.unbindFire)
+	removeEventHandler("onClientPlayerWasted",localPlayer,functions.unbindFire)
 end
 
-local block
-function limitedKeyPress (key,keyState,speed)
-	if keyState == "down" then
-		if block == true then return end
-		shooting = true
-		pressKey ( "vehicle_fire" )
-		block = true
-		setTimer ( function() block = false end, speed, 1 )
-		limiterTimer = setTimer ( pressKey,speed, 0, "vehicle_fire" )
-	else
-		shooting = false
-		for k,timer in ipairs(getTimers()) do
-			if timer == limiterTimer then
-				killTimer ( limiterTimer )
-			end
-		end
-	end
-end
 
-function pressKey ( controlName )
+functions.pressKey = function ( controlName )
 	setControlState ( controlName, true )
 	setTimer ( setControlState, 150, 1, controlName, false )
 end
 
----Left/right toggling
-local bikes = { [581]=true,[509]=true,[481]=true,[462]=true,[521]=true,[463]=true,
-	[510]=true,[522]=true,[461]=true,[448]=true,[468]=true,[586]=true }
-function toggleTurningKeys(vehicleID, state)
+
+functions.blockfalse = function()
+	block = false 
+end 
+
+
+functions.limitedKeyPress = function(key,keyState,speed)
+	if keyState == "down" then
+		if not block then
+			shooting = true
+			functions.pressKey ( "vehicle_fire" )
+			block = true
+			setTimer ( functions.blockfalse, speed, 1 )
+			limiterTimer = setTimer ( functions.pressKey, speed, 0, "vehicle_fire" )
+		end
+	else
+		shooting = false
+		if isTimer ( limiterTimer ) then
+			killTimer ( limiterTimer )
+		end
+	end
+end
+
+
+functions.toggleTurningKeys = function(vehicleID, state)
 	if bikes[vehicleID] then
 		if not settings.steerBikes then
 			toggleControl ( "vehicle_left", state )
 			toggleControl ( "vehicle_right", state )
 		end
-	else
-		if not settings.steerCars then
-			toggleControl ( "vehicle_left", state )
-			toggleControl ( "vehicle_right", state )
-		end
+	elseif not settings.steerCars then
+		toggleControl ( "vehicle_left", state )
+		toggleControl ( "vehicle_right", state )
 	end
 end
+
+
+--[[ Block driveby when exiting vehicle: 
+  setPedDoingGangDriveby ejects the player if he is trying to get out of the vehicle (without animations ) ]]
+addEventHandler ( "onClientVehicleStartExit", root, function ( player )
+	if player == localPlayer then
+		exitingvehicle = true
+	end
+end )
 	
-function fadeInHelp()
-	if helpAnimation then helpAnimation:remove() end
-	local _,_,_,a = helpText:color()
-	if a == 255 then return end
-	helpAnimation = Animation.createAndPlay(helpText, Animation.presets.dxTextFadeIn(300))
-	setTimer ( function() helpText:color(255,255,255,255) end, 300, 1 )
-end
 
-function fadeOutHelp()
-	if helpAnimation then helpAnimation:remove() end
-	local _,_,_,a = helpText:color()
-	if a == 0 then return end
-	helpAnimation = Animation.createAndPlay(helpText, Animation.presets.dxTextFadeOut(300))
-	setTimer ( function() helpText:color(255,255,255,0) end, 300, 1 )
-end
-
-local function onWeaponSwitchWhileDriveby (prevSlot, curSlot)
-	if isPedDoingGangDriveby(source) then	
-		limitDrivebySpeed(getPedWeapon(source, curSlot))
+--This function simply sets up the driveby upon vehicle entry
+addEventHandler( "onClientPlayerVehicleEnter", localPlayer, function ( _, seat )
+	--If his seat is 0, store the fact that he's a driver
+	exitingvehicle = false 
+	driver = seat == 0
+	lastSlot = 0
+	--By default, we set the player's equiped weapon to nothing.
+	setPedWeaponSlot( localPlayer, 0 )
+	if settings.autoEquip then
+		functions.toggleDriveby()
 	end
-end
-addEventHandler ("onClientPlayerWeaponSwitch", localPlayer, onWeaponSwitchWhileDriveby)
+end )
+
+
+addEventHandler ("onClientPlayerWeaponSwitch", localPlayer, function ( _, curSlot )
+	if isPedDoingGangDriveby(source) then	
+		functions.limitDrivebySpeed(getPedWeapon(source, curSlot))
+	end
+end )
+
+
+--Tell the server the clientside script was downloaded and started
+addEventHandler ( "onClientResourceStart", resourceRoot, function()
+	bindKey ( "mouse2", "down", "Toggle Driveby", "" )
+	bindKey ( "e", "down", "Next driveby weapon", "1" )
+	bindKey ( "q", "down", "Previous driveby weapon", "-1" )
+	toggleControl ( "vehicle_next_weapon",false )
+	toggleControl ( "vehicle_previous_weapon",false )
+	triggerServerEvent ( "driveby_clientScriptLoaded", localPlayer )
+	helpText = dxText:create("",0.5,0.85)
+	helpText:scale(1)
+	helpText:type("stroke",1)
+end )
+
+
+addEventHandler ( "onClientResourceStop", resourceRoot, function()
+	toggleControl ( "vehicle_next_weapon",true )
+	toggleControl ( "vehicle_previous_weapon",true )
+end )
+
+
+addEventHandler ( "deletePedForDrivebyFix", root, function ( )
+	if peds[source] then
+		pedowner[peds[source]] = nil 
+	end
+	peds[source] = nil 
+end )
+
+
+addEventHandler ( "savePedForDrivebyFix", root, function ( ped ) 
+	local veh = getPedOccupiedVehicle ( source )
+	if isElement ( veh ) then
+		--setElementAlpha ( ped, 0 )
+		peds[source] = ped 
+		pedowner[ped] = source
+		addEventHandler ( "onClientPedDamage", ped, pedGotHit )
+		--setElementCollidableWith ( ped, veh, false )
+		if source == localPlayer then
+			setElementCollisionsEnabled ( ped, false )
+		else 
+			setElementCollisionsEnabled ( ped, true )
+		end
+		
+	end
+end )


### PR DESCRIPTION
1. You could eject yourself immediately by pressing F (enter exit vehicle) and mouse2 (driveby) - without animations.
That happened because of setPedDoingGangDriveby.
2. If you used a weapon, which isn't allowed for the driver, on another seat, you couldn't switch weapons as driver.
3. You could use not allowed weapons as a drive by using the weapon on another seat and go back as driver
4. Switching weapons let you shoot fast with slow weapons like Deagle
5. New function to replace the hitbox while using driveby on a bike with the hitbox of an attached ped - only working for clientsided damagesystem with attacker triggering the damage
6. Better performance by localizing the variables