### PR TITLE
Remove unnecessary showCursor function

### DIFF
--- a/[admin]/admin/client/colorpicker/colorpicker.lua
+++ b/[admin]/admin/client/colorpicker/colorpicker.lua
@@ -77,7 +77,7 @@ function colorPicker.create(id, start, title)
   addEventHandler("onClientGUIBlur", cp.gui.window, cp.handlers.guiBlur, false)
   addEventHandler("onClientGUIClick", cp.gui.okb, cp.handlers.pickColor, false)
   addEventHandler("onClientGUIClick", cp.gui.closeb, cp.handlers.destroy, false)  
-  showCursor(true)
+  --showCursor(true)
   return cp
 end
 


### PR DESCRIPTION
The cursor is already handled by admin panel and the extra showCursor function in colorpicker just makes it difficult for other resources to use it.