### PR TITLE
Support hydra and hunter kills > driven vehicles in killfeed

### DIFF
--- a/[gameplay]/killmessages/killmessages_client.lua
+++ b/[gameplay]/killmessages/killmessages_client.lua
@@ -1,4 +1,33 @@
-﻿addEvent ("onClientPlayerKillMessage",true)
+local specialVehicleDamagerModels =
+{
+	[520] = true,
+	[425] = true,
+}
+
+function onAirstrikeDamaged(att, wep, loss)
+	local localVeh = getPedOccupiedVehicle(localPlayer)
+	if att and getElementType(att) == "player" and att ~= localPlayer and localVeh and source == localVeh and loss > 0 then
+		if isPedInVehicle(att) and specialVehicleDamagerModels[getElementModel(getPedOccupiedVehicle(att))] then
+			if not isTimer(hydradmgcd) then
+				hydradmgcd = setTimer(function() end, 100, 1)
+				setElementData(localPlayer, "km.hydradmg", att, false)
+				setTimer(setElementData, 500, 1, localPlayer, "km.hydradmg", false)
+			end
+		end
+	end
+end
+addEventHandler ("onClientVehicleDamage", root, onAirstrikeDamaged)
+	
+function onClientWasted(killer, weapon, bodypart)
+	if isPedInVehicle(source) and getElementData(source, "km.hydradmg") then
+		return triggerServerEvent("onWastedPlayerKillMessageRequest", localPlayer, getElementData(source, "km.hydradmg"), 59, 0)
+	else
+		triggerServerEvent("onWastedPlayerKillMessageRequest", source, killer, weapon, bodypart)
+	end
+end
+addEventHandler ("onClientPlayerWasted", localPlayer, onClientWasted)
+
+addEvent ("onClientPlayerKillMessage",true)
 function onClientPlayerKillMessage ( killer,weapon,wr,wg,wb,kr,kg,kb,width,resource )
 	if wasEventCancelled() then return end
 	outputKillMessage ( source, wr,wg,wb,killer,kr,kg,kb,weapon,width,resource )


### PR DESCRIPTION
This will make hydra/hunter kills on vehicles show up in killfeed. Previously when you shot a player in vehicle directly with the Hydra/hunter rockets or hunter machinegun, it would not detect you as killer and show ''blown'' only.
The method used is the only way to detect these kills, although I've never seen this ''guessing'' being inaccurate so far. Tested for months.