### PR TITLE
[interiors] Fix player being stuck sometimes

### DIFF
--- a/[gameplay]/interiors/interiors_client.lua
+++ b/[gameplay]/interiors/interiors_client.lua
@@ -159,9 +159,11 @@ local idLoc = { ["interiorReturn"] = "refid",["interiorEntry"] = "id" }
 function colshapeHit( player, matchingDimension )
 	if not isElement ( player ) or getElementType ( player ) ~= "player" then return end
 	if player ~= localPlayer then return end
-	if ( not matchingDimension ) or ( isPedInVehicle ( player ) ) or 
+	if ( not matchingDimension ) or ( getPedOccupiedVehicle ( player ) ) or 
 	( doesPedHaveJetPack ( player ) ) or ( not isPedOnGround ( player ) ) or 
-	( getControlState ( "aim_weapon" ) ) or ( blockPlayer ) 
+	( getControlState ( "aim_weapon" ) ) or ( blockPlayer ) or 
+	( isPedDoingTask ( player, "TASK_COMPLEX_ENTER_CAR_AS_DRIVER") ) or 
+	( isPedDoingTask ( player, "TASK_COMPLEX_ENTER_CAR_AS_PASSENGER") ) 
 	then return end
 	local interior = interiorFromCol[source]
 	local id = getElementData ( interior, idLoc[getElementType(interior)] ) 


### PR DESCRIPTION
Fixes two issues:
1) If you jump out vehicle, and later that vehicle touch marker, you will stuck in between interiors: https://youtu.be/rO0bQVbCDRQ
Fixed by simply replacing `isPedInVehicle` to `getPedOccupiedVehicle` (which return element also when player is leaving vehicle).

2) If you enter vehicle while you are being teleported, you will stuck: https://youtu.be/FzkNWI8olhg
Fixed by disallowing teleport when player is entering vehicle.