### PR TITLE
[freeroam] Added anti-bothering features (disable warp & knifing, ''anti ram'' vehicle ghostmode)

### DIFF
--- a/[gameplay]/freeroam/meta.xml
+++ b/[gameplay]/freeroam/meta.xml
@@ -87,6 +87,9 @@
 		<setting name="*vehicles/disallowed" value="[[432]]" />   <!-- Comma-separated list of vehicles that players may not create -->
 		<setting name="*chat/mainChatDelay" value="1000" />   <!-- Miliseconds between each message a player can send through main chat -->
 		<setting name="*chat/blockRepeatMessages" value="true" />   <!-- Prevent a player from saying the same thing twice in a row to spam -->
+		<setting name="*gui/antiram" value="true" />
+		<setting name="*gui/disablewarp" value="true" />
+		<setting name="*gui/disableknife" value="true" />
 		<setting name="@command_spam_protection" value="true"
 					friendlyname="Command Spam Protection"
 					accept="true,false"


### PR DESCRIPTION
These newly implemented features are tickboxes in F1 allowing the player to eliminate some common bothering done by other players, such as ramming their vehicles (anti ram, aka vehicle ghostmode option), constantly knife instakilling them (from behind; stealthkill) now preventable with ''disable knifing'', and stopping other players from warping to them directly (using '''disable warp''). The concept for all of these features has been tested on the most popular freeroam server of right now, for more than a year, and they proved to be a very welcome addition for the average Freeroam player. It fits a gamemode like this perfectly.
Anyways, dialogue and discussion is still welcome in comments below.


