### PR TITLE
FreeRoam Bug

### DIFF
--- a/[gameplay]/headshot/headshot.lua
+++ b/[gameplay]/headshot/headshot.lua
@@ -1,4 +1,6 @@
-﻿addEvent "onPlayerHeadshot"
+local removeHeadOnHeadshot = get("removeHeadOnHeadshot");
+
+addEvent "onPlayerHeadshot"
 
 addEventHandler("onPlayerDamage", getRootElement(),
 	function (attacker, weapon, bodypart, loss)
@@ -6,7 +8,19 @@ addEventHandler("onPlayerDamage", getRootElement(),
 			local result = triggerEvent("onPlayerHeadshot", source, attacker, weapon, loss)
 			if result == true then
 				killPed(source, attacker, weapon, bodypart)
+				if removeHeadOnHeadshot then
+					setPedHeadless(source, true)
+				end
 			end
+		end
+	end
+)
+
+addEventHandler("onPlayerSpawn", getRootElement(), 
+	function()
+		-- Restore head if it got blown off
+		if removeHeadOnHeadshot and source:isHeadless() then
+			setPedHeadless(source, false)
 		end
 	end
 )

--- a/[gameplay]/headshot/meta.xml
+++ b/[gameplay]/headshot/meta.xml
@@ -1,4 +1,11 @@
 <meta>
-	<info author="jbeta" type="script" version="1.0.0" />
+	<info author="jbeta" type="script" version="1.1.0" />
 	<script src="headshot.lua" type="server" />
+	<settings>
+		<setting name="*removeHeadOnHeadshot" value="true"
+			friendlyname="Blows off player's head on headshot"
+			group="General"
+			accept="false,true"
+			desc="Should player lose his head when he gets headshot?" />
+	</settings>
 </meta>


### PR DESCRIPTION
Hi
i find a bug on freeroam script v1.5.5
https://github.com/multitheftauto/mtasa-resources/commit/d40d040aa0b6e0b8c9379933e7a69e82ca4e4c49#diff-334220ff27684b48cae02dacdb1db588R1808

if you exit vehicle the button fix , upgrades, color and paintjob dont hide
and upgrade ,color windows don't hide
and the curvehicle lable don't change to On Foot