### PR TITLE
[admin] Added logging for ACL changes, unban etc

### DIFF
--- a/[admin]/admin/conf/messages.xml
+++ b/[admin]/admin/conf/messages.xml
@@ -247,22 +247,7 @@
     </group>
   </server>
   <bans>
-    <group action="unbanip" r="225" g="170" b="90">
-      <admin>IP: $data successfully removed from bans list</admin>
-      <log>ADMIN: $admin has unbanned IP $data</log>
-    </group>
-    <group action="unbanserial" r="225" g="170" b="90">
-      <admin>SERIAL: $data successfully removed from bans list</admin>
-      <log>ADMIN: $admin has unbanned Serial $data</log>
-    </group>
-    <group action="banip" r="225" g="170" b="90">
-      <admin>IP: $data successfully added to bans list</admin>
-      <log>ADMIN: $admin has banned IP $data</log>
-    </group>
-    <group action="banserial" r="225" g="170" b="90">
-      <admin>SERIAL: $data successfully added to bans list</admin>
-      <log>ADMIN: $admin has banned Serial $data</log>
-    </group>
+
   </bans>
   <admin>
     <group action="create" r="225" g="170" b="90">

--- a/[admin]/admin/server/admin_server.lua
+++ b/[admin]/admin/server/admin_server.lua
@@ -706,11 +706,16 @@ addEventHandler ( "aAdmin", _root, function ( action, ... )
 				mdata = "Group "..name
 				if ( not aclCreateGroup ( name ) ) then
 					action = nil
+				else
+				
+				outputServerLog ("ACL: "..getPlayerName(source).."["..getAccountName (getPlayerAccount(source)).."] ["..getPlayerSerial (source).."] ["..getPlayerIP (source).."] created "..mdata)
 				end
 			elseif ( arg[1] == "acl" ) then
 				mdata = "ACL "..name
 				if ( not aclCreate ( name ) ) then
 					action = nil
+				else
+				outputServerLog ("ACL: "..getPlayerName(source).."["..getAccountName (getPlayerAccount(source)).."] ["..getPlayerSerial (source).."] ["..getPlayerIP (source).."] created "..mdata)
 				end
 			end
 			triggerEvent ( "aAdmin", source, "sync", "aclgroups" )
@@ -723,6 +728,7 @@ addEventHandler ( "aAdmin", _root, function ( action, ... )
 			if ( aclGetGroup ( name ) ) then
 				mdata = "Group "..name
 				aclDestroyGroup ( aclGetGroup ( name ) )
+				outputServerLog ("ACL: "..getPlayerName(source).."["..getAccountName (getPlayerAccount(source)).."] ["..getPlayerSerial (source).."] ["..getPlayerIP (source).."] destroyed "..mdata)
 			else
 				action = nil
 			end
@@ -730,6 +736,7 @@ addEventHandler ( "aAdmin", _root, function ( action, ... )
 			if ( aclGet ( name ) ) then
 				mdata = "ACL "..name
 				aclDestroy ( aclGet ( name ) )
+				outputServerLog ("ACL: "..getPlayerName(source).."["..getAccountName (getPlayerAccount(source)).."] ["..getPlayerSerial (source).."] ["..getPlayerIP (source).."] destroyed "..mdata)
 			else
 				action = nil
 			end
@@ -747,6 +754,7 @@ addEventHandler ( "aAdmin", _root, function ( action, ... )
 					outputChatBox ( "Error adding object '"..tostring ( object ).."' to group '"..tostring ( arg[2] ).."'", source, 255, 0, 0 )
 				else
 					mdata2 = "Object '"..arg[3].."'"
+				outputServerLog ("ACL: "..getPlayerName(source).."["..getAccountName (getPlayerAccount(source)).."] ["..getPlayerSerial (source).."] ["..getPlayerIP (source).."] added "..object.." to ACL Group "..arg[2])
 					triggerEvent ( "aAdmin", source, "sync", "aclobjects", arg[2] )
 				end
 			elseif ( arg[1] == "acl" ) then
@@ -758,6 +766,7 @@ addEventHandler ( "aAdmin", _root, function ( action, ... )
 				else
 					mdata2 = "ACL '"..arg[3].."'"
 					triggerEvent ( "aAdmin", source, "sync", "aclobjects", arg[2] )
+				outputServerLog ("ACL: "..getPlayerName(source).."["..getAccountName (getPlayerAccount(source)).."] ["..getPlayerSerial (source).."] ["..getPlayerIP (source).."] added "..mdata2.." to Group "..arg[2])
 				end
 			elseif ( arg[1] == "right" ) then
 				local acl = aclGet ( arg[2] )
@@ -769,6 +778,7 @@ addEventHandler ( "aAdmin", _root, function ( action, ... )
 				else
 					mdata2 = "Right '"..arg[3].."'"
 					triggerEvent ( "aAdmin", source, "sync", "aclrights", arg[2] )
+				outputServerLog ("ACL: "..getPlayerName(source).."["..getAccountName (getPlayerAccount(source)).."] ["..getPlayerSerial (source).."] ["..getPlayerIP (source).."] added "..mdata2.." to ACL "..arg[2])
 				end
 			end
 		else
@@ -788,6 +798,7 @@ addEventHandler ( "aAdmin", _root, function ( action, ... )
 				else
 					mdata2 = "Object '"..arg[3].."'"
 					triggerEvent ( "aAdmin", source, "sync", "aclobjects", arg[2] )
+				outputServerLog ("ACL: "..getPlayerName(source).."["..getAccountName (getPlayerAccount(source)).."] ["..getPlayerSerial (source).."] ["..getPlayerIP (source).."] removed "..mdata2)
 				end
 			elseif ( arg[1] == "acl" ) then
 				local group = aclGetGroup ( arg[2] )
@@ -798,6 +809,7 @@ addEventHandler ( "aAdmin", _root, function ( action, ... )
 				else
 					mdata2 = "ACL '"..arg[3].."'"
 					triggerEvent ( "aAdmin", source, "sync", "aclobjects", arg[2] )
+				outputServerLog ("ACL: "..getPlayerName(source).."["..getAccountName (getPlayerAccount(source)).."] ["..getPlayerSerial (source).."] ["..getPlayerIP (source).."] removed "..mdata2)
 				end
 			elseif ( arg[1] == "right" ) then
 				local acl = aclGet ( arg[2] )
@@ -809,13 +821,14 @@ addEventHandler ( "aAdmin", _root, function ( action, ... )
 					mdata = "ACL '"..arg[2].."'"
 					mdata2 = "Right '"..arg[3].."'"
 					triggerEvent ( "aAdmin", source, "sync", "aclrights", arg[2] )
+				outputServerLog ("ACL: "..getPlayerName(source).."["..getAccountName (getPlayerAccount(source)).."] ["..getPlayerSerial (source).."] ["..getPlayerIP (source).."] removed "..mdata2.." from "..mdata)
 				end
 			end
 		else
 			action = nil
 		end
 	end
-	if ( action ~= nil ) then aAction ( "admin", action, source, false, mdata, mdata2 ) end
+	--if ( action ~= nil ) then aAction ( "admin", action, source, false, mdata, mdata2 ) end
 end )
 
 
@@ -848,7 +861,7 @@ addEventHandler ( "aPlayer", _root, function ( player, action, data, additional,
 			mdata = reason~="" and ( "(" .. reason .. ")" ) or ""
 			local isAnonAdmin = getElementData(source, "AnonAdmin")
 			if isAnonAdmin then
-				setTimer ( kickPlayer, 100, 1, player, root, reason )
+				setTimer ( kickPlayer, 100, 1, player, "Anonymous admin", reason )
 			else
 				setTimer ( kickPlayer, 100, 1, player, source, reason )
 			end
@@ -1485,6 +1498,7 @@ addEventHandler ( "aBans", _root, function ( action, data, arg1, arg2, arg3 )
 			action = nil
 			for i,ban in ipairs(getBans ()) do
 				if getBanIP(ban) == data then
+				
 					action = removeBan ( ban, source )
 				end
 			end
@@ -1595,3 +1609,15 @@ function checkNickOnChange(old, new)
 	end
 end
 addEventHandler("onPlayerChangeNick", root, checkNickOnChange)
+
+addEventHandler ("onUnban",root,function(theBan,responsibleElement)
+	if getElementType (responsibleElement)=="player" then
+		outputServerLog ("BAN: "..getPlayerName(responsibleElement).."["..getAccountName (getPlayerAccount(responsibleElement)).."] ["..getPlayerSerial (responsibleElement).."] ["..getPlayerIP (responsibleElement).."] unbanned player "..(getBanNick(theBan) or "unknown").." ["..(getBanIP (theBan) or getBanSerial(theBan)).."] ")
+	end
+end)
+
+addEventHandler ("onBan",root,function(theBan)
+	if getElementType (source)=="player" then
+		outputServerLog ("BAN: "..getPlayerName(source).."["..getAccountName (getPlayerAccount(source)).."] ["..getPlayerSerial (source).."] ["..getPlayerIP (source).."] banned player "..(getBanNick(theBan) or "unknown").." ["..(getBanIP (theBan) or getBanSerial(theBan)).."] ")
+	end
+end)

--- a/[admin]/admin/server/admin_server.lua
+++ b/[admin]/admin/server/admin_server.lua
@@ -1611,13 +1611,13 @@ end
 addEventHandler("onPlayerChangeNick", root, checkNickOnChange)
 
 addEventHandler ("onUnban",root,function(theBan,responsibleElement)
-	if getElementType (responsibleElement)=="player" then
+	if isElement(responsibleElement) and getElementType (responsibleElement)=="player" then
 		outputServerLog ("BAN: "..getPlayerName(responsibleElement).."["..getAccountName (getPlayerAccount(responsibleElement)).."] ["..getPlayerSerial (responsibleElement).."] ["..getPlayerIP (responsibleElement).."] unbanned player "..(getBanNick(theBan) or "unknown").." ["..(getBanIP (theBan) or getBanSerial(theBan)).."] ")
 	end
 end)
 
 addEventHandler ("onBan",root,function(theBan)
-	if getElementType (source)=="player" then
+	if isElement(source) and getElementType (source)=="player" then
 		outputServerLog ("BAN: "..getPlayerName(source).."["..getAccountName (getPlayerAccount(source)).."] ["..getPlayerSerial (source).."] ["..getPlayerIP (source).."] banned player "..(getBanNick(theBan) or "unknown").." ["..(getBanIP (theBan) or getBanSerial(theBan)).."] ")
 	end
 end)


### PR DESCRIPTION
When admins change something in ACL (add user, right, resource, new ACL, delete nodes, or rights) it will now log who did that and specify the exact right/element that was modified and in which way. Previously, a nondescriptive (hardcoded server) message just stated something had changed only, so for server owners, (malicious) actions could hardly be traced back to a specific admin.

Also added: more extensive logging for unbanning and banning offline players, for example it will now specify the serial/IP which gets unbanned and by who, instead of just stating a ban was removed.