### PR TITLE
[scoreboard] Fix for potential dxscoreboard_countries.lua errors

### DIFF
--- a/[gameplay]/freeroam/gui.lua
+++ b/[gameplay]/freeroam/gui.lua
@@ -184,7 +184,7 @@ function _buildWindow(wnd, baseWnd, parentWnd)
 		guiBringToFront(elem)
 		g_openedWindows[wnd] = true
 	elseif wndClass == 'chk' then
-		elem = guiCreateCheckBox(relX, relY, relWidth, relHeight, wnd.text or wnd.id or '', false, true, parentWnd.element)
+		elem = guiCreateCheckBox(relX, relY, relWidth, relHeight, wnd.text or wnd.id or '', wnd.selected or false, true, parentWnd.element)
 	elseif wndClass == 'tbp' then
 		elem = guiCreateTabPanel(relX, relY, relWidth, relHeight, true, parentWnd.element)
 	elseif wndClass == 'tab' then

--- a/[gameplay]/scoreboard/dxscoreboard_countries.lua
+++ b/[gameplay]/scoreboard/dxscoreboard_countries.lua
@@ -12,16 +12,21 @@ end
 showCountries = toboolean( get( "showCountries" ) ) or false
 
 if showCountries then
-local countryData = "Country"
-local defaultCountryIndicator = "N/A" --If something somehow fails and setting is enabled in meta.xml
-	for i,players in ipairs(getElementsByType("player")) do
-		local cCode = exports.admin:getPlayerCountry(players)
-		setElementData(players,countryData,{":admin/client/images/flags/"..string.lower(cCode or defaultCountryIndicator)..".png",cCode or defaultCountryIndicator})
+	local isAdminResourceRunning = getResourceFromName( "admin" )
+	isAdminResourceRunning = isAdminResourceRunning and getResourceState( isAdminResourceRunning ) == "running"
+
+	local countryData = "Country"
+	local defaultCountryIndicator = "N/A" -- If something somehow fails and setting is enabled in meta.xml
+
+	for i, player in ipairs( getElementsByType( "player" ) ) do
+		local cCode = isAdminResourceRunning and exports.admin:getPlayerCountry( player ) or defaultCountryIndicator
+		setElementData( player, countryData, {":admin/client/images/flags/" .. cCode:lower() .. ".png", cCode} )
 	end
 
-	function setScoreboardData ()
-		local cCode = exports.admin:getPlayerCountry(source)
-		setElementData(source, countryData,{":admin/client/images/flags/"..string.lower(cCode or defaultCountryIndicator)..".png",cCode or defaultCountryIndicator})
+	function setScoreboardData()
+		local cCode = isAdminResourceRunning and exports.admin:getPlayerCountry( source ) or defaultCountryIndicator
+		setElementData( source, countryData, {":admin/client/images/flags/" .. cCode:lower() .. ".png", cCode} )
 	end
-addEventHandler("onPlayerJoin", getRootElement(), setScoreboardData)
+
+	addEventHandler( "onPlayerJoin", getRootElement(), setScoreboardData )
 end

--- a/[gameplay]/scoreboard/dxscoreboard_http.lua
+++ b/[gameplay]/scoreboard/dxscoreboard_http.lua
@@ -35,7 +35,7 @@ local function calculateWidth()
 end
 
 local function getRowData( element )
-	local rowData = { getElementType( element ), }
+	local rowData = { getElementType( element ) }
 	for key, column in ipairs( httpColumns ) do
 		if column.name == "name" then
 			table.insert( rowData, getName( element ) )


### PR DESCRIPTION
Edit: Creating a new branch in my fork referencing a bugs.mtasa.com issue id, rather than through master for obvious reasons, sorry for an illogical PR, realized it myself :P

`[gameplay]/scoreboard/dxscoreboard_countries.lua:18` and `[gameplay]/scoreboard/dxscoreboard_countries.lua:23` would throw server-side errors if the `admin` resource was not running.

```
ERROR: scoreboard\dxscoreboard_countries.lua:18: exports: Call to non-running server resource (admin) [string "?"]
ERROR: scoreboard\dxscoreboard_countries.lua:23: exports: Call to non-running server resource (admin) [string "?"]
```

Also removed an unnecessary comma from a table in `[gameplay]/scoreboard/dxscoreboard_http.lua:38`.