### PR TITLE
[FIX] freeroam: Fix setpos blackscreen and error on start

### DIFF
--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -1972,7 +1972,7 @@ end
 addEventHandler('onClientResourceStart', resourceRoot,
 	function()
 		fadeCamera(true)
-		setTimer(getPlayers, 1000, 1)
+		getPlayers()
 		setJetpackMaxHeight ( 9001 )
 		triggerServerEvent('onLoadedAtClient', resourceRoot)
 		createWindow(wndMain)
@@ -2046,9 +2046,8 @@ function wastedHandler()
 end
 
 local function removeForcedFade()
-
 	removeEventHandler("onClientPreRender",root,forceFade)
-
+	fadeCamera(true)
 end
 
 local function checkCustomSpawn()


### PR DESCRIPTION
Fix the blackscreen occurring after using /sp when dead.
Also fixes error at line 1016 that occurs upon every start.

Closes #121