### PR TITLE
[scoreboard] add ability for server staff to spoof countryflag

### DIFF
--- a/[gameplay]/scoreboard/dxscoreboard_countries.lua
+++ b/[gameplay]/scoreboard/dxscoreboard_countries.lua
@@ -30,3 +30,35 @@ if showCountries then
 
 	addEventHandler( "onPlayerJoin", getRootElement(), setScoreboardData )
 end
+
+-- Server staff can use the below command to spoof their country-code in TAB scoreboard to avoid undesired recognition by players.
+-- Don't be too obvious, it's advised to pick a country close to your own (to simulate a realistic client > server ping for said country)
+addCommandHandler("setcountry",
+	function(thePlayer, command, country_code)
+		local player_account = getPlayerAccount(thePlayer)
+		if not player_account then
+			outputChatBox("* You're not logged in.", thePlayer, 255, 100, 100)
+			return false
+		end
+		local account_name = getAccountName(player_account)
+		if not isObjectInACLGroup("user."..account_name, aclGetGroup("Admin")) and isObjectInACLGroup("user."..account_name, aclGetGroup("Moderator")) then
+			outputChatBox("* You don't have permission to do that.", thePlayer, 255, 100, 100)
+			return false
+		end
+		if not country_code then
+			outputChatBox("* Usage: /setcountry countrycode", thePlayer, 255, 100, 100)
+			outputChatBox("* Example: /setcountry ru", thePlayer, 255, 100, 100)
+			return false
+		end
+		country_code = string.lower(country_code)
+		local img = ":admin/client/images/flags/"..country_code..".png"
+		if not fileExists(img) then
+			outputChatBox("* Sorry, '"..country_code.."' is not an existing country code.", thePlayer, 255, 100, 100)
+			return false
+		end
+		country_code = string.upper(country_code)
+		setElementData(thePlayer, "Country", {img, country_code})
+		outputChatBox("* Your country has been set to "..country_code.."!", thePlayer, 100, 255, 100)
+		return true
+	end
+)


### PR DESCRIPTION
Faking the country flag can be done to prevent undesired recognition by players, which I realized is a downside of the flags feature. Admins may be located in a rare country (per the server's playerbase) or reconnect quickly under another nick and may want to remain anonymous.

PR is used to circumvent some GIT issue. However due to the unusual nature of this feature it will permit discussion of it.