### PR TITLE
freeroam: Fix GUI after destroy vehicle (GUI wasnt updated for passengers)

### DIFF
--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -1858,7 +1858,7 @@ function onEnterVehicle(vehicle,seat)
 end
 
 function onExitVehicle(vehicle,seat)
-	if (eventName == "onClientPlayerVehicleExit" and source == localPlayer) or (eventName == "onClientElementDestroy" and getElementType(source) == "vehicle" and getVehicleController(source) == localPlayer) then
+	if (eventName == "onClientPlayerVehicleExit" and source == localPlayer) or (eventName == "onClientElementDestroy" and getElementType(source) == "vehicle" and getPedOccupiedVehicle(localPlayer) == source) then
 		setControlText(wndMain, 'curvehicle', 'On foot')
 		hideControls(wndMain, 'repair', 'flip', 'upgrades', 'color', 'paintjob', 'lightson', 'lightsoff')
 		closeWindow(wndUpgrades)


### PR DESCRIPTION
This PR fixes GUI not being updated properly when a vehicle has been destroyed (passengers GUIs werent updated as it should)

Previous PR: https://github.com/multitheftauto/mtasa-resources/pull/125

- Luxy.c