### PR TITLE
admin2: renamed conf/settings.db to admin.db

### DIFF
--- a/[admin]/admin2/server/admin_database.lua
+++ b/[admin]/admin2/server/admin_database.lua
@@ -9,7 +9,7 @@
 **************************************]]
 
 -- ensure old database file gets renamed
-if(fileExists("conf/settings.db")) then
+if (fileExists("conf/settings.db")) then
     fileRename("conf/settings.db", "admin.db")
 end
 

--- a/[admin]/admin2/server/admin_database.lua
+++ b/[admin]/admin2/server/admin_database.lua
@@ -9,7 +9,9 @@
 **************************************]]
 
 -- ensure old database file gets renamed
-fileRename("conf\\settings.db", "admin.db")
+if(fileExists("conf\\settings.db")) then
+    fileRename("conf\\settings.db", "admin.db")
+end
 
 db = {
     connection = dbConnect("sqlite", "admin.db"),

--- a/[admin]/admin2/server/admin_database.lua
+++ b/[admin]/admin2/server/admin_database.lua
@@ -9,8 +9,8 @@
 **************************************]]
 
 -- ensure old database file gets renamed
-if(fileExists("conf\\settings.db")) then
-    fileRename("conf\\settings.db", "admin.db")
+if(fileExists("conf/settings.db")) then
+    fileRename("conf/settings.db", "admin.db")
 end
 
 db = {

--- a/[admin]/admin2/server/admin_database.lua
+++ b/[admin]/admin2/server/admin_database.lua
@@ -7,8 +7,41 @@
 *	Original File by lil_Toady
 *
 **************************************]]
+
+-- ensure old database file gets renamed
+if(fileExists("conf\\settings.db")) then
+    local bRemoveOldFile = true
+    
+    if(not fileExists("admin.db")) then
+        local uOldFile = fileOpen("conf\\settings.db")
+        local uNewFile = fileCreate("admin.db")
+        
+        -- rename file
+        if(uOldFile and uNewFile) then
+            fileWrite(uNewFile, fileRead(uOldFile, fileGetSize(uOldFile)))
+            fileFlush(uNewFile)
+        end
+        
+        -- ensure file handlers getting closed
+        if(uOldFile) then
+            fileClose(uOldFile)
+        end
+        
+        if(uNewFile) then
+            fileClose(uNewFile)
+        end
+    else
+        bRemoveOldFile = false
+    end
+    
+    -- remove old database file on success
+    if(bRemoveOldFile) then
+        fileDelete("conf\\settings.db")
+    end
+end
+
 db = {
-    connection = dbConnect("sqlite", "conf\\settings.db"),
+    connection = dbConnect("sqlite", "admin.db"),
     results = {},
     timers = {},
     threads = {}
@@ -40,7 +73,7 @@ end
 
 function db.query(query, ...)
     local cr = coroutine.running()
-
+    
     local handle = dbQuery(db.callback, db.connection, query, ...)
 
     db.threads[handle] = cr

--- a/[admin]/admin2/server/admin_database.lua
+++ b/[admin]/admin2/server/admin_database.lua
@@ -9,36 +9,7 @@
 **************************************]]
 
 -- ensure old database file gets renamed
-if(fileExists("conf\\settings.db")) then
-    local bRemoveOldFile = true
-    
-    if(not fileExists("admin.db")) then
-        local uOldFile = fileOpen("conf\\settings.db")
-        local uNewFile = fileCreate("admin.db")
-        
-        -- rename file
-        if(uOldFile and uNewFile) then
-            fileWrite(uNewFile, fileRead(uOldFile, fileGetSize(uOldFile)))
-            fileFlush(uNewFile)
-        end
-        
-        -- ensure file handlers getting closed
-        if(uOldFile) then
-            fileClose(uOldFile)
-        end
-        
-        if(uNewFile) then
-            fileClose(uNewFile)
-        end
-    else
-        bRemoveOldFile = false
-    end
-    
-    -- remove old database file on success
-    if(bRemoveOldFile) then
-        fileDelete("conf\\settings.db")
-    end
-end
+fileRename("conf\\settings.db", "admin.db")
 
 db = {
     connection = dbConnect("sqlite", "admin.db"),


### PR DESCRIPTION
Renames current conf\settings.db to admin.db. The reason for this change is for further implementations such as whowas, network tab, logging and maybe more :)

- Luxy.c