### PR TITLE
Fix #137: Add exported functions and setting to toggle realdriveby on/off

### DIFF
--- a/[gameplay]/realdriveby/driveby_client.lua
+++ b/[gameplay]/realdriveby/driveby_client.lua
@@ -77,6 +77,9 @@ addEventHandler("doSendDriveBySettings",localPlayer,
 				end
 			end )
 		end
+		if not settings.enabled then
+			toggleDriveby()
+		end
 	end
 )
 
@@ -89,7 +92,7 @@ function toggleDriveby()
 	if settings.blockedVehicles[vehicleID] then return end
 	--Has he got a weapon equiped?
 	local equipedWeapon = getPedWeaponSlot( localPlayer )
-	if equipedWeapon == 0 then
+	if settings.enabled and equipedWeapon == 0 then
 		if exitingVehicle then return end
 		--Decide whether he is a driver or passenger
 		--We need to get the switchTo weapon by finding any valid IDs

--- a/[gameplay]/realdriveby/driveby_server.lua
+++ b/[gameplay]/realdriveby/driveby_server.lua
@@ -1,4 +1,4 @@
-local settings = {
+settings = {
 	driver = get"driveby_driver" or { 22,23,24,25,28,29,32 },
 	passenger = get"driveby_passenger" or { 22,23,24,25,26,28,29,32,30,31,33 },
 	shotdelay = get"driveby_shot_delay" or { ['22']=300,['23']=300,['24']=800,['26']=700 },
@@ -7,6 +7,7 @@ local settings = {
 	steerBikes = get"driveby_steer_bikes" == true,
 	autoEquip = get"driveby_auto_equip" or false,
 	blockInstantEject = get"block_instant_eject" == true,
+	enabled = get"driveby_enabled" == true,
 }
 --Remove any BS IDs by checking them
 local validDrivebyWeapons = { [22]=true,[23]=true,[24]=true,[25]=true,
@@ -33,3 +34,13 @@ addEventHandler ( "driveby_clientScriptLoaded", getRootElement(),
 	end
 )
 
+-- Save player specific driveby enabled-states
+syncedPlayerStates = {}
+
+addEvent("driveby_syncDrivebyState", true)
+addEventHandler("driveby_syncDrivebyState", root,
+	function(enabled)
+		if client ~= source then return end
+		syncedPlayerStates[client] = enabled
+	end
+)

--- a/[gameplay]/realdriveby/exports_client.lua
+++ b/[gameplay]/realdriveby/exports_client.lua
@@ -91,4 +91,25 @@ function getDrivebyAutoEquip ()
 	return settings.autoEquip
 end
 
+function isDrivebyEnabled()
+	return settings.enabled
+end
 
+function setDrivebyEnabled(enabled, syncToServer)
+	local enabledType = type(enabled)
+	assert(enabledType == "boolean", "Bad argument @ 'setDrivebyEnabled' [Expected boolean at argument 1, got " .. enabledType .. "]")
+
+	settings.enabled = enabled
+
+	-- Let's remove any active player driveby state
+	if not settings.enabled then
+		toggleDriveby()
+	end
+
+	-- Sync updated state to the server unless explicitly requested not to
+	if syncToServer ~= false then
+		triggerServerEvent("driveby_syncDrivebyState", localPlayer, settings.enabled)
+	end
+end
+addEvent("driveby_setDrivebyEnabled", true)
+addEventHandler("driveby_setDrivebyEnabled", root, setDrivebyEnabled)

--- a/[gameplay]/realdriveby/exports_server.lua
+++ b/[gameplay]/realdriveby/exports_server.lua
@@ -1,11 +1,11 @@
 function isDrivebyEnabled(player)
 	assert(isElement(player) and getElementType(player) == "player", "Bad argument @ 'isDrivebyEnabled' [Expected player at argument 1, got " .. type(player) .. "]")
 
-	if syncedPlayerStates[player] == nil then
-		return settings.enabled
+	if syncedPlayerStates[player] ~= nil then
+		return syncedPlayerStates[player]
 	end
 
-	return syncedPlayerStates[player] or false
+	return settings.enabled
 end
 
 function setDrivebyEnabled(player, state)

--- a/[gameplay]/realdriveby/exports_server.lua
+++ b/[gameplay]/realdriveby/exports_server.lua
@@ -1,7 +1,11 @@
 function isDrivebyEnabled(player)
 	assert(isElement(player) and getElementType(player) == "player", "Bad argument @ 'isDrivebyEnabled' [Expected player at argument 1, got " .. type(player) .. "]")
 
-	return syncedPlayerStates[player] == nil and settings.enabled or syncedPlayerStates[player] or false
+	if syncedPlayerStates[player] == nil then
+		return settings.enabled
+	end
+
+	return syncedPlayerStates[player] or false
 end
 
 function setDrivebyEnabled(player, state)

--- a/[gameplay]/realdriveby/exports_server.lua
+++ b/[gameplay]/realdriveby/exports_server.lua
@@ -1,0 +1,16 @@
+function isDrivebyEnabled(player)
+	assert(isElement(player) and getElementType(player) == "player", "Bad argument @ 'isDrivebyEnabled' [Expected player at argument 1, got " .. type(player) .. "]")
+
+	return syncedPlayerStates[player] == nil and settings.enabled or syncedPlayerStates[player]
+end
+
+function setDrivebyEnabled(player, state)
+	assert(isElement(player) and getElementType(player) == "player", "Bad argument @ 'setDrivebyEnabled' [Expected player at argument 1, got " .. type(player) .. "]")
+
+	local stateType = type(state)
+	assert(stateType == "boolean", "Bad argument @ 'setDrivebyEnabled' [Expected boolean at argument 2, got " .. stateType .. "]")
+
+	syncedPlayerStates[player] = state
+
+	triggerClientEvent(player, "driveby_setDrivebyEnabled", player, state, false)
+end

--- a/[gameplay]/realdriveby/exports_server.lua
+++ b/[gameplay]/realdriveby/exports_server.lua
@@ -1,7 +1,7 @@
 function isDrivebyEnabled(player)
 	assert(isElement(player) and getElementType(player) == "player", "Bad argument @ 'isDrivebyEnabled' [Expected player at argument 1, got " .. type(player) .. "]")
 
-	return syncedPlayerStates[player] == nil and settings.enabled or syncedPlayerStates[player]
+	return syncedPlayerStates[player] == nil and settings.enabled or syncedPlayerStates[player] or false
 end
 
 function setDrivebyEnabled(player, state)

--- a/[gameplay]/realdriveby/meta.xml
+++ b/[gameplay]/realdriveby/meta.xml
@@ -3,6 +3,7 @@
 	<script src="driveby_client.lua" type="client" />
 	<script src="exports_client.lua" type="client" />
 	<script src="driveby_server.lua" type="server" />
+	<script src="exports_server.lua" type="server" />
 
 	<!--utils-->
 	<script src="utils/textlib.lua" type="client" />
@@ -33,6 +34,9 @@
 
 		<!--Block instant eject when using driveby while exiting vehicle -->
 		<setting name="block_instant_eject" value="[true]"/>
+
+		<!--Whether or not is driveby enabled for all players by default -->
+		<setting name="driveby_enabled" value="[true]"/>
 	</settings>
 	<export function="setDriverDrivebyAbility" type="client" />
 	<export function="setPassengerDrivebyAbility" type="client" />
@@ -44,4 +48,6 @@
 	<export function="getDrivebySteeringAbility" type="client" />
 	<export function="setDrivebyAutoEquip" type="client" />
 	<export function="getDrivebyAutoEquip" type="client" />
+	<export function="isDrivebyEnabled" type="shared" />
+	<export function="setDrivebyEnabled" type="shared" />
 </meta>


### PR DESCRIPTION
This commit, once applied, enables toggling of the *realdriveby* feature for a specific player.

Fixes #137

## New exported functions
### Server
  - `bool isDrivebyEnabled ( player thePlayer )`
  - `bool setDrivebyEnabled ( player thePlayer, bool enabled )`

### Client
  - `bool isDrivebyEnabled ( )`
  - `bool setDrivebyEnabled ( bool enabled [, bool syncToServer ] )`

## Add new `meta.xml` setting
  - `driveby_enabled` (default value: `true`)
