### PR TITLE
admin: improved player mod details view

### DIFF
--- a/[admin]/admin/client/gui/admin_moddetails.lua
+++ b/[admin]/admin/client/gui/admin_moddetails.lua
@@ -14,7 +14,7 @@ function aViewModdetails ( player )
 	modDetailsPlayer = player
 	if ( aModdetailsForm == nil ) then
 		local x, y = guiGetScreenSize()
-		aModdetailsForm	= guiCreateWindow ( x / 2 - 250, y / 2 - 125, 500, 350, "View Modetails", false )
+		aModdetailsForm	= guiCreateWindow ( x / 2 - 250, y / 2 - 125, 500, 350, "View Mod Details", false )
 		guiWindowSetSizable( aModdetailsForm, false )
 		aModdetailsList		= guiCreateGridList ( 0.02, 0.09, 0.72, 0.85, true, aModdetailsForm )
 					   guiGridListAddColumn( aModdetailsList, "Filename", 0.3 )
@@ -79,7 +79,7 @@ function aClientModdetailsClick ( button )
 			triggerServerEvent ( "aModdetails", resourceRoot, "get", modDetailsPlayer )
 		elseif ( source == aModdetailsCopy ) then
 			setClipboard ( toJSON ( currentModDetails ) )
-			outputChatBox("* Player mod information copied to clipboard.", 255, 100, 70)
+			outputChatBox("* Player mod details copied to clipboard.", 255, 100, 70)
 		end
 	end
 end

--- a/[admin]/admin/client/gui/admin_moddetails.lua
+++ b/[admin]/admin/client/gui/admin_moddetails.lua
@@ -8,16 +8,18 @@
 
 aModdetailsForm = nil
 local modDetailsPlayer = nil
+local currentModDetails
 
 function aViewModdetails ( player )
 	modDetailsPlayer = player
 	if ( aModdetailsForm == nil ) then
 		local x, y = guiGetScreenSize()
-		aModdetailsForm	= guiCreateWindow ( x / 2 - 250, y / 2 - 125, 350, 350, "View Moddetails", false )
+		aModdetailsForm	= guiCreateWindow ( x / 2 - 250, y / 2 - 125, 500, 350, "View Modetails", false )
 		guiWindowSetSizable( aModdetailsForm, false )
 		aModdetailsList		= guiCreateGridList ( 0.02, 0.09, 0.72, 0.85, true, aModdetailsForm )
-					   guiGridListAddColumn( aModdetailsList, "Id", 0.25 )
-					   guiGridListAddColumn( aModdetailsList, "Name", 0.60 )
+					   guiGridListAddColumn( aModdetailsList, "Filename", 0.3 )
+					   guiGridListAddColumn( aModdetailsList, "Modification", 0.60 )
+		aModdetailsCopy		= guiCreateButton ( 0.76, 0.71, 0.32, 0.05, "Copy", true, aModdetailsForm )
 		aModdetailsRefresh	= guiCreateButton ( 0.76, 0.78, 0.32, 0.05, "Refresh", true, aModdetailsForm )
 		aModdetailsClose	= guiCreateButton ( 0.76, 0.85, 0.32, 0.05, "Close", true, aModdetailsForm )
 		addEventHandler ( "aModdetails", resourceRoot, aModdetailsSync )
@@ -43,6 +45,7 @@ function aViewModdetailsClose ( destroy )
 	else
 		guiSetVisible ( aModdetailsForm, false )
 	end
+	currentModDetails = nil
 end
 
 function aModdetailsSync ( action, list, player )
@@ -50,15 +53,20 @@ function aModdetailsSync ( action, list, player )
 		return
 	end
 	if ( action == "get" ) then
-		guiGridListClear ( aModdetailsList )
-		destroyElement ( aModdetailsList )
-		aModdetailsList	= guiCreateGridList ( 0.02, 0.09, 0.72, 0.85, true, aModdetailsForm )
-					   guiGridListAddColumn( aModdetailsList, "Id", 0.25 )
-					   guiGridListAddColumn( aModdetailsList, "Name", 0.60 )
-		for id,mod in ipairs( list ) do
-			local row = guiGridListAddRow ( aModdetailsList )
-			guiGridListSetItemText ( aModdetailsList, row, 1, tostring(mod.id), false, false )
-			guiGridListSetItemText ( aModdetailsList, row, 2, tostring(mod.name), false, false )
+		currentModDetails = list
+		if not aModdetailsList then
+			aModdetailsList	= guiCreateGridList ( 0.02, 0.09, 0.72, 0.85, true, aModdetailsForm )
+			guiGridListAddColumn( aModdetailsList, "Filename", 0.3 )
+			guiGridListAddColumn( aModdetailsList, "Modification", 0.60 )
+		else
+			guiGridListClear ( aModdetailsList )
+		end
+		for filename, mods in pairs( list ) do
+			for _, mod in ipairs(mods) do
+				local row = guiGridListAddRow ( aModdetailsList )
+				guiGridListSetItemText ( aModdetailsList, row, 1, tostring(filename), false, false )
+				guiGridListSetItemText ( aModdetailsList, row, 2, tostring(mod.name), false, false )
+			end
 		end
 	end
 end
@@ -69,6 +77,9 @@ function aClientModdetailsClick ( button )
 			aViewModdetailsClose ( false )
 		elseif ( source == aModdetailsRefresh ) then
 			triggerServerEvent ( "aModdetails", resourceRoot, "get", modDetailsPlayer )
+		elseif ( source == aModdetailsCopy ) then
+			setClipboard ( toJSON ( currentModDetails ) )
+			outputChatBox("* Player mod information copied to clipboard.", 255, 100, 70)
 		end
 	end
 end

--- a/[admin]/admin/server/admin_server.lua
+++ b/[admin]/admin/server/admin_server.lua
@@ -1459,7 +1459,7 @@ addEventHandler ( "aModdetails", resourceRoot, function ( action, player )
 	if checkClient( false, client, 'aModdetails', action ) then return end
 	if ( hasObjectPermissionTo ( client, "general.adminpanel" ) ) then
 		if ( action == "get" ) then
-			triggerClientEvent ( client, "aModdetails", resourceRoot, "get", getPlayerImgModsList(player), player )
+			triggerClientEvent ( client, "aModdetails", resourceRoot, "get", getPlayerModInfo(player), player )
 		end
 	end
 end )


### PR DESCRIPTION
This PR:

- Fixes #146 by adding a copy button to the player mod details view. Mod data is output in JSON format, for example:
```[
   {
      "gta3.img":[
         {
            "hash":1884619590,
            "paddedLength":137216,
            "id":20038,
            "sha256":"DCE74CCF98956F4674BA483CF020D565DE312C53CD0CAB9FA0F66EAD3FDD25AE",
            "paddedSha256":"D0EB8509152DE9A042F0883521DD8F331E0B202F4944AF6502B4A3F87507AAFD",
            "name":"colt45.txd",
            "md5":"0EA9CDB5CC5DEAD8DF16A50004E4EE7D",
            "length":136616,
            "paddedMd5":"F1333E03A4515523D0371EDDD915321C"
         },
         {
            "originalSizeY":0.15000001,
            "originalSizeX":0.44,
            "paddedLength":49152,
            "id":346,
            "paddedMd5":"CE7B9114FC455CC3E9C7D0971F0F6924",
            "sizeX":0.23,
            "sizeY":0.039999999,
            "paddedSha256":"C8EF9F8D1C64E67135F341CBCD2CF70399E6242B5B81CD4DB5F130E49203E8CF",
            "originalSizeZ":0.20999999,
            "name":"colt45.dff",
            "md5":"3006F97435EEA1E23E3522FADC5B4B87",
            "sha256":"C14FE13464150D814466337FFF0035878E543261975B18A4CF4104735E334FDC",
            "length":48464,
            "hash":2933035898,
            "sizeZ":0.18000001
         }
```
- Changes mods in the view to be listed by filename and mod name, rather than ID and mod name.
- Makes the mod info window a little wider (150px).