### PR TITLE
add chat2 resource

### DIFF
--- a/[gameplay]/chat2/chat2_client.lua
+++ b/[gameplay]/chat2/chat2_client.lua
@@ -1,0 +1,87 @@
+local chatInstance
+local chatInstanceLoading
+local chatInstanceLoaded
+
+addEvent("onChat2Loaded")
+addEvent("onChat2Input")
+addEvent("onChat2SendMessage")
+addEvent("onChat2Output", true)
+addEvent("onChat2Clear", true)
+addEvent("onChat2Show", true)
+
+function execute(eval)
+  executeBrowserJavascript(chatInstance, eval)
+end
+
+function create()
+  chatInstance = guiGetBrowser(guiCreateBrowser(0.01, 0.01, 0.25, 0.4, true, true, true))
+  chatInstanceLoading = true
+  addEventHandler("onClientBrowserCreated", chatInstance, load)
+end
+
+function load()
+  loadBrowserURL(chatInstance, "http://mta/local/index.html")
+end
+
+function output(message)
+  if not chatInstanceLoaded then
+    return setTimer(output, 250, 1, message)
+  end
+
+  local eval = string.format("addMessage(%s)", toJSON(message))
+  execute(eval)
+end
+
+function clear()
+  local eval = "clear()"
+  execute(eval)
+end
+
+function show(bool)
+  if chatInstanceLoaded ~= true then
+    if chatInstanceLoading ~= true then
+      create()
+      setTimer(show, 300, 1, bool)
+    else
+      setTimer(show, 300, 1, bool)
+    end
+  end
+
+  local eval = "show(" .. tostring(bool) .. ");"
+  execute(eval)
+  setElementData(localPlayer, "chat2IsVisible", bool)
+end
+
+function isVisible()
+  return getElementData(localPlayer, "chat2IsVisible", false)
+end
+
+function onResourceStart()
+  showChat(false)
+  show(true)
+end
+
+function onChatLoaded()
+  chatInstanceLoaded = true
+  focusBrowser(chatInstance)
+end
+
+function onChatInput(isActive)
+  if isActive == "true" then
+    guiSetInputEnabled(true)
+  else
+    guiSetInputEnabled(false)
+  end
+end
+
+function onChatSendMessage(message)
+  triggerServerEvent("onChat2SendMessage", resourceRoot, message)
+end
+
+addEventHandler("onClientResourceStart", resourceRoot, onResourceStart)
+addEventHandler("onChat2Loaded", resourceRoot, onChatLoaded)
+addEventHandler("onChat2Input", resourceRoot, onChatInput)
+addEventHandler("onChat2SendMessage", resourceRoot, onChatSendMessage)
+addEventHandler("onChat2Output", localPlayer, output)
+addEventHandler("onChat2Clear", localPlayer, clear)
+addEventHandler("onChat2Show", localPlayer, show)

--- a/[gameplay]/chat2/chat2_server.lua
+++ b/[gameplay]/chat2/chat2_server.lua
@@ -1,0 +1,73 @@
+addEvent("onChat2SendMessage", true)
+addEvent("onPlayerChat2")
+
+local isDefaultOutput = true
+local minLength = 1
+local maxLength = 96
+
+function clear(player)
+  triggerClientEvent(player, "onChat2Clear", player)
+end
+
+function show(player, bool)
+  triggerClientEvent(player, "onChat2Show", player, bool)
+end
+
+function isVisible(player)
+  return getElementData(player, "chat2IsVisible", false)
+end
+
+function output(player, message)
+  triggerClientEvent(player, "onChat2Output", player, message)
+end
+
+function useDefaultOutput(bool)
+  isDefaultOutput = bool
+end
+
+function onChatSendMessage(message)
+  local sender = client
+  local nickname = getPlayerName(sender)
+
+  if type(message) ~= "string" or utf8.len(message) < minLength or utf8.len(message) > maxLength then
+    return
+  end
+
+  if utf8.sub(message, 0, 1) == "/" then
+    handleCommand(sender, message)
+    return
+  end
+
+  if not isDefaultOutput then
+    triggerEvent("onPlayerChat2", root, sender, message)
+    return
+  end
+
+  for _, player in ipairs(getElementsByType("player")) do
+    local text = string.format("%s#ffffff: %s", nickname, message)
+    output(player, text)
+    outputServerLog(text)
+  end
+end
+
+function handleCommand(client, input)
+  local splittedInput = split(input, " ")
+  local cmd = utf8.sub(splittedInput[1], 2, utf8.len(splittedInput[1]))
+  local args = {}
+
+  for i, arg in ipairs(splittedInput) do
+    if (i ~= 1) then
+      args[i - 1] = arg
+    end
+  end
+
+  for i, part in ipairs(splittedInput) do
+    if i == 1 then
+      cmd = utf8.sub(part, i + 1, utf8.len(part))
+    end
+  end
+
+  executeCommandHandler(cmd, client, unpack(args))
+end
+
+addEventHandler("onChat2SendMessage", resourceRoot, onChatSendMessage)

--- a/[gameplay]/chat2/index.html
+++ b/[gameplay]/chat2/index.html
@@ -1,0 +1,334 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <style>
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+      }
+
+      .chat {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-flow: column;
+        justify-content: space-between;
+        text-shadow: 0 0.25vh 0vh #000;
+        color: #ffffff;
+        overflow-x: hidden;
+        user-select: none;
+      }
+
+      .chat.hidden {
+        visibility: hidden;
+      }
+
+      .chat__messages-container {
+        position: absolute;
+        max-height: 100%;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+      }
+
+      .chat__messages {
+        position: relative;
+        height: 80%;
+        overflow-y: scroll;
+      }
+
+      .chat__messages::-webkit-scrollbar {
+        width: 0.1vh;
+      }
+
+      .chat__messages::-webkit-scrollbar-track,
+      .chat__messages::-webkit-scrollbar-thumb {
+        background-color: transparent;
+      }
+
+      .chat__message {
+        word-break: break-all;
+        font-size: 5vh;
+        line-height: 130%;
+        font-family: sans-serif;
+        font-weight: 700;
+      }
+
+      .chat__message:last-child {
+        margin-bottom: 0;
+      }
+
+      .chat__input {
+        padding: 2vh;
+        margin-top: 2vh;
+        width: 100%;
+        background-color: rgba(0, 0, 0, 0.25);
+        border: 1px solid rgba(0, 0, 0, 0.25);
+        color: #fff;
+        font-size: 4vh;
+        text-shadow: 0 0.1vh 0.2vh rgba(0, 0, 0, 0.5);
+        font-family: sans-serif;
+        font-weight: 700;
+      }
+
+      .chat__input.hidden {
+        display: none;
+      }
+
+      .chat__input:focus {
+        outline: none;
+      }
+    </style>
+
+    <div class="chat hidden">
+      <div class="chat__messages">
+        <div class="chat__messages-container"></div>
+      </div>
+      <input maxlength="96" type="text" class="chat__input hidden" />
+    </div>
+
+    <script>
+      const keyCodes = {
+        t: 84,
+        enter: 13,
+        tab: 9,
+        pageUp: 33,
+        pageDown: 34
+      };
+
+      const state = {
+        show: true,
+        showInput: false,
+        inputMessage: "",
+        scroll: false,
+        canScrollToBottom: true,
+        lastRegisteredDelayCallback: null
+      };
+
+      let elements;
+
+      function show(bool) {
+        state.show = bool;
+        if (!bool) return elements.chat.classList.add("hidden");
+        elements.chat.classList.remove("hidden");
+
+        scrollToBottom();
+      }
+
+      function showInput(bool) {
+        state.showInput = bool;
+        if (!bool) return elements.input.classList.add("hidden");
+        elements.input.classList.remove("hidden");
+      }
+
+      function addMessage([message]) {
+        if (!state.show) return;
+
+        render(message);
+        scrollToBottom();
+      }
+
+      function scrollToBottom(force = false) {
+        if (force) {
+          state.canScrollToBottom = true;
+          state.lastRegisteredDelayCallback = null;
+        }
+
+        if (!state.canScrollToBottom) return;
+
+        elements.chatMessages.scrollTo({
+          top: elements.chatMessages.scrollHeight,
+          behavior: "smooth"
+        });
+      }
+
+      function preventPressTab(e) {
+        if (e.keyCode == keyCodes.tab) e.preventDefault();
+      }
+
+      function render(message) {
+        const messageElement = document.createElement("div");
+        messageElement.classList.add("chat__message");
+        const messageFragment = document.createDocumentFragment();
+
+        processTextWithHexCode(message).forEach(({ part, color }) => {
+          const partElement = document.createElement("span");
+          partElement.innerText = part;
+          partElement.style.color = color;
+          messageFragment.appendChild(partElement);
+        });
+
+        messageElement.append(messageFragment);
+        elements.chatMessagesContainer.append(messageElement);
+      }
+
+      function scroll() {
+        if (!state.scroll) return;
+        const value = state.scroll == keyCodes.pageUp ? -5 : 5;
+        elements.chatMessages.scrollBy({ top: value });
+        setTimeout(scroll, 25);
+      }
+
+      function clear() {
+        elements.chatMessagesContainer.innerHTML = "";
+      }
+
+      function processTextWithHexCode(text) {
+        const result = [];
+        const regex = /#[0-9abcdefABCDEF]{6}/;
+        const parts = [];
+        const sharpPositions = [];
+
+        text.split("").forEach((v, i) => {
+          if (v == "#") sharpPositions.push(i);
+        });
+
+        if (!sharpPositions.length) {
+          result.push({ part: text, color: null });
+          return result;
+        }
+
+        if (sharpPositions[0] != 0) {
+          result.push({ part: text.slice(0, sharpPositions[0]), color: null });
+        }
+
+        sharpPositions.forEach((position, i, arr) => {
+          const nextPosition =
+            typeof arr[i + 1] == "number" ? arr[i + 1] : undefined;
+          parts.push(text.slice(position, nextPosition));
+        });
+
+        parts.forEach(part => {
+          if (regex.test(part)) {
+            result.push({
+              part: part.replace(regex, ""),
+              color: part.match(regex)[0]
+            });
+          } else {
+            result.push({
+              part,
+              color: null
+            });
+          }
+        });
+
+        return result;
+      }
+
+      function onKeydownInputButton(ev) {
+        if (!state.show) return;
+        if (ev.keyCode !== keyCodes.t) return;
+        if (state.showInput) return;
+
+        showInput(true);
+        setTimeout(() => {
+          mta.triggerEvent("onChat2Input", "true");
+          elements.input.focus();
+        }, 0);
+      }
+
+      function onKeydownEnterButton(ev) {
+        if (!state.show) return;
+        if (ev.keyCode !== keyCodes.enter) return;
+        if (!state.showInput) return;
+
+        const inputMessage = elements.input.value;
+        elements.input.value = "";
+
+        showInput(false);
+        mta.triggerEvent("onChat2SendMessage", inputMessage);
+        setTimeout(mta.triggerEvent, 100, "onChat2Input", "false");
+        scrollToBottom(true);
+      }
+
+      function onKeydownScrollButton(ev) {
+        const { keyCode } = ev;
+        const { pageUp, pageDown } = keyCodes;
+
+        if (!state.show) return;
+        if (keyCode !== pageUp && keyCode !== pageDown) return;
+        if (state.scroll) return;
+
+        if (keyCode == pageUp) state.scroll = pageUp;
+        else state.scroll = pageDown;
+
+        scroll();
+      }
+
+      function onKeyupScrollButton(ev) {
+        const { keyCode } = ev;
+        const { pageUp, pageDown } = keyCodes;
+
+        if (!state.show) return;
+        if (keyCode !== pageUp && keyCode !== pageDown) return;
+        if (!state.scroll) return;
+
+        state.scroll = false;
+
+        const isEndOfScroll =
+          elements.chatMessages.scrollHeight -
+            elements.chatMessages.scrollTop -
+            parseInt(getComputedStyle(elements.chatMessages).height) ==
+          1;
+
+        if (isEndOfScroll) {
+          state.canScrollToBottom = true;
+          state.lastRegisteredDelayCallback = null;
+          return;
+        }
+
+        state.canScrollToBottom = false;
+
+        let registeredCallback = function() {
+          if (!state.lastRegisteredDelayCallback) return;
+
+          if (
+            registeredCallback.uniqueId !==
+            state.lastRegisteredDelayCallback.uniqueId
+          ) {
+            return;
+          }
+
+          state.canScrollToBottom = true;
+          scrollToBottom();
+          state.lastRegisteredDelayCallback = null;
+        };
+        registeredCallback.uniqueId = Date.now();
+
+        state.lastRegisteredDelayCallback = registeredCallback;
+        setTimeout(registeredCallback, 5000);
+      }
+
+      function onDOMContentLoaded() {
+        elements = {
+          chat: document.querySelector(".chat"),
+          input: document.querySelector(".chat__input"),
+          chatMessages: document.querySelector(".chat__messages"),
+          chatMessagesContainer: document.querySelector(
+            ".chat__messages-container"
+          )
+        };
+
+        elements.input.addEventListener("keydown", preventPressTab);
+        document.addEventListener("keydown", onKeydownScrollButton);
+        document.addEventListener("keyup", onKeyupScrollButton);
+        mta.triggerEvent("onChat2Loaded");
+      }
+
+      document.addEventListener("DOMContentLoaded", onDOMContentLoaded);
+      document.addEventListener("keydown", onKeydownInputButton);
+      document.addEventListener("keydown", onKeydownEnterButton);
+    </script>
+  </body>
+</html>

--- a/[gameplay]/chat2/meta.xml
+++ b/[gameplay]/chat2/meta.xml
@@ -1,0 +1,13 @@
+<meta>
+  <info name="chat" type="script" version="0.1.0" author="nrzull" />
+
+  <script src="chat2_server.lua" type="server" />
+  <script src="chat2_client.lua" type="client" />
+  <file src="index.html" />
+
+  <export function="clear" type="shared" />
+  <export function="show" type="shared" />
+  <export function="output" type="shared" />
+  <export function="isVisible" type="shared" />
+  <export function="useDefaultOutput" type="server" />
+</meta>


### PR DESCRIPTION
## Description
This chat is using CEF and it tries to become full replacement for default chat

## Pros
- Emojis (😈)
- Adaptive (you don't need to put-on glasses for your 1920x1080 screen to see what others write)
- Copy/paste from/to input (no more console -> say someLongMessageOrUrl)
- Customizable (now you can unify a chat for all of your players)

## Cons
- For execution of custom commands resource needs an access right for [ExecuteCommandHandler](https://wiki.multitheftauto.com/wiki/ExecuteCommandHandler) in ACL
- It can't execute built-in commands like `/nick`, `/login`, etc "due to security reasons." (c) mta wiki
- It can't be used until resource starts so you can't write useful messages to player in `onPlayerConnect` event handler

## API
### Clientside
#### Functions
- **output(string message) -> void**
Writes a message to chat. Hex colors processing is enabled by default and this behavior can't be configured by end-user.

- **clear() -> void**
Clears all messages. Chat doesn't have history.

- **isVisible() -> bool**
Returns true/false if chat is visible.

- **show(bool b) -> void**
Shows/hides a chat.

### Serverside
#### Functions
- **output(element player, string message) -> void**
- **clear(element player) -> void**
- **isVisible(element player) -> bool**
- **show(element player, bool b) -> void**

#### Events
- **onPlayerChat2**
handler params: (element player, string message)
Will be emitted only after useDefaultOutput(false)

### Examples:
```lua
addEventHandler("onPlayerJoin", root, function()
 exports.chat2:output(source, "#ccff00hello from default output #ffcc00chat")
 exports.chat2:useDefaultOutput(false) -- disable built-in handler and use own handlers that listen for "onPlayerChat2" event
end)

addEventHandler("onPlayerChat2", root, function(sender, message)
 for _, player in ipairs(getElementsByType("player")) do
    local text = string.format("%s wrote: %s", nickname, message)
    output(player, text)
  end
end)
```
