### PR TITLE
admin2: fix messageBox usage

### DIFF
--- a/[admin]/admin2/client/main/admin_bans.lua
+++ b/[admin]/admin2/client/main/admin_bans.lua
@@ -41,29 +41,25 @@ function aBansTab.onClientClick(button)
     if (button == "left") then
         if (source == aBansTab.Details) then
             if (guiGridListGetSelectedItem(aBansTab.BansList) == -1) then
-                aMessageBox("error", "No ban row selected!")
+                messageBox("No ban row selected!", MB_ERROR, MB_OK)
             else
                 local ip = guiGridListGetItemText(aBansTab.BansList, guiGridListGetSelectedItem(aBansTab.BansList), 2)
                 aBanDetails(ip)
             end
         elseif (source == aBansTab.Unban) then
             if (guiGridListGetSelectedItem(aBansTab.BansList) == -1) then
-                aMessageBox("error", "No ban row selected!")
+                messageBox("No ban row selected!", MB_ERROR, MB_OK)
             else
                 local selected =
                     guiGridListGetItemText(aBansTab.BansList, guiGridListGetSelectedItem(aBansTab.BansList), 2)
                 if (aBans["Serial"][selected]) then
-                    aMessageBox(
-                        "question",
-                        "Unban Serial " .. selected .. "?",
-                        'triggerServerEvent ( "aBans", getLocalPlayer(), "unbanserial", "' .. selected .. '" )'
-                    )
+                    if (messageBox("Unban Serial " .. selected .. "?", MB_QUESTION, MB_YESNO ) == true) then
+                        triggerServerEvent ( "aBans", getLocalPlayer(), "unbanserial", selected )
+                    end
                 else
-                    aMessageBox(
-                        "question",
-                        "Unban IP " .. selected .. "?",
-                        'triggerServerEvent ( "aBans", getLocalPlayer(), "unbanip", "' .. selected .. '" )'
-                    )
+                    if (messageBox("Unban IP " .. selected .. "?", MB_QUESTION, MB_YESNO) == true) then
+                        triggerServerEvent ( "aBans", getLocalPlayer(), "unbanip", selected )
+                    end
                 end
             end
         elseif (source == aBansTab.BansRefresh) then

--- a/[admin]/admin2/client/main/admin_options.lua
+++ b/[admin]/admin2/client/main/admin_options.lua
@@ -95,13 +95,13 @@ function aOptionsTab.onClientClick(button)
                 guiGetText(aOptionsTab.PasswordNew),
                 guiGetText(aOptionsTab.PasswordConfirm)
             if (passwordNew == "") then
-                aMessageBox("error", "Enter the new password")
+                messageBox("Enter the new password", MB_ERROR, MB_OK)
             elseif (passwordConf == "") then
-                aMessageBox("error", "Confirm the new password")
+                messageBox("Confirm the new password", MB_ERROR, MB_OK)
             elseif (string.len(passwordNew) < 4) then
-                aMessageBox("error", "The new password must be at least 4 characters long")
+                messageBox("The new password must be at least 4 characters long", MB_ERROR, MB_OK)
             elseif (passwordNew ~= passwordConf) then
-                aMessageBox("error", "Confirmed password doesn't match")
+                messageBox("Confirmed password doesn't match", MB_ERROR, MB_OK)
             else
                 triggerServerEvent(
                     "aAdmin",

--- a/[admin]/admin2/client/main/admin_resources.lua
+++ b/[admin]/admin2/client/main/admin_resources.lua
@@ -97,7 +97,7 @@ function aResourcesTab.onClientClick(button)
                 (source == aResourcesTab.ResourceStop))
          then
             if (guiGridListGetSelectedItem(aResourcesTab.ResourceList) == -1) then
-                aMessageBox("error", "No resource selected!")
+                messageBox("No resource selected!", MB_ERROR, MB_OK)
             else
                 local name =
                     guiGridListGetItemText(

--- a/[admin]/admin2/client/main/backup!.lua
+++ b/[admin]/admin2/client/main/backup!.lua
@@ -874,7 +874,7 @@ function aClientClick(button)
                     guiBringToFront(aTab1.SlapDropDown)
                 end
                 if (guiGridListGetSelectedItem(aTab1.PlayerList) == -1) then
-                    aMessageBox("error", "No player selected!")
+                    messageBox("No player selected!", MB_ERROR, MB_OK)
                 else
                     local name =
                         guiGridListGetItemText(aTab1.PlayerList, guiGridListGetSelectedItem(aTab1.PlayerList), 1)
@@ -898,12 +898,9 @@ function aClientClick(button)
                     elseif (source == aTab1.Slap) then
                         triggerServerEvent("aPlayer", getLocalPlayer(), player, "slap", aCurrentSlap)
                     elseif (source == aTab1.Mute) then
-                        aMessageBox(
-                            "question",
-                            "Are you sure to " .. iif(aPlayers[player]["mute"], "unmute", "mute") .. " " .. name .. "?",
-                            'triggerServerEvent ( "aPlayer", getLocalPlayer(), getPlayerFromNick ( "' ..
-                                name .. '" ), "mute" )'
-                        )
+                        if (messageBox("Are you sure to " .. iif(aPlayers[player]["mute"], "unmute", "mute") .. " " .. name .. "?", MB_QUESTION, MB_YESNO) == true) then
+                            triggerServerEvent ( "aPlayer", getLocalPlayer(), getPlayerFromNick ( name ), "mute" )
+                        end
                     elseif (source == aTab1.Freeze) then
                         triggerServerEvent("aPlayer", getLocalPlayer(), player, "freeze")
                     elseif (source == aTab1.Spectate) then
@@ -983,19 +980,13 @@ function aClientClick(button)
                         aVehicleCustomize(player)
                     elseif (source == aTab1.Admin) then
                         if (aPlayers[player]["admin"]) then
-                            aMessageBox(
-                                "warning",
-                                "Revoke admin rights from " .. name .. "?",
-                                'triggerServerEvent ( "aPlayer", getLocalPlayer(), getPlayerFromNick ( "' ..
-                                    name .. '" ), "setgroup", false )'
-                            )
+                            if (messageBox("Revoke admin rights from " .. name .. "?", MB_WARNING, MB_YESNO) == true) then
+                                triggerServerEvent ( "aPlayer", getLocalPlayer(), getPlayerFromNick ( name ), "setgroup", false )
+                            end
                         else
-                            aMessageBox(
-                                "warning",
-                                "Give admin rights to " .. name .. "?",
-                                'triggerServerEvent ( "aPlayer", getLocalPlayer(), getPlayerFromNick ( "' ..
-                                    name .. '" ), "setgroup", true )'
-                            )
+                            if (messageBox("Give admin rights to " .. name .. "?", MB_WARNING, MB_YESNO) == true) then
+                                triggerServerEvent ( "aPlayer", getLocalPlayer(), getPlayerFromNick ( name ), "setgroup", true )
+                            end
                         end
                     end
                 end
@@ -1080,7 +1071,7 @@ function aClientClick(button)
             -- TAB 3, WORLD
             if ((source == aTab2.ResourceStart) or (source == aTab2.ResourceRestart) or (source == aTab2.ResourceStop)) then
                 if (guiGridListGetSelectedItem(aTab2.ResourceList) == -1) then
-                    aMessageBox("error", "No resource selected!")
+                    messageBox("No resource selected!", MB_ERROR, MB_OK)
                 else
                     if (source == aTab2.ResourceStart) then
                         triggerServerEvent(
@@ -1230,29 +1221,25 @@ function aClientClick(button)
             -- TAB 5, ADMIN CHAT
             if (source == aTab4.Details) then
                 if (guiGridListGetSelectedItem(aTab4.BansList) == -1) then
-                    aMessageBox("error", "No ban row selected!")
+                    messageBox("No ban row selected!", MB_ERROR, MB_OK)
                 else
                     local ip = guiGridListGetItemText(aTab4.BansList, guiGridListGetSelectedItem(aTab4.BansList), 2)
                     aBanDetails(ip)
                 end
             elseif (source == aTab4.Unban) then
                 if (guiGridListGetSelectedItem(aTab4.BansList) == -1) then
-                    aMessageBox("error", "No ban row selected!")
+                    messageBox("No ban row selected!", MB_ERROR, MB_OK)
                 else
                     local selected =
                         guiGridListGetItemText(aTab4.BansList, guiGridListGetSelectedItem(aTab4.BansList), 2)
                     if (aBans["Serial"][selected]) then
-                        aMessageBox(
-                            "question",
-                            "Unban Serial " .. selected .. "?",
-                            'triggerServerEvent ( "aBans", getLocalPlayer(), "unbanserial", "' .. selected .. '" )'
-                        )
+                        if (messageBox("Unban Serial " .. selected .. "?", MB_QUESTION, MB_YESNO) == true) then
+                            triggerServerEvent ( "aBans", getLocalPlayer(), "unbanserial", selected )
+                        end
                     else
-                        aMessageBox(
-                            "question",
-                            "Unban IP " .. selected .. "?",
-                            'triggerServerEvent ( "aBans", getLocalPlayer(), "unbanip", "' .. selected .. '" )'
-                        )
+                        if (messageBox("Unban IP " .. selected .. "?", MB_QUESTION, MB_YESNO) == true) then
+                            triggerServerEvent ( "aBans", getLocalPlayer(), "unbanip",  selected )
+                        end
                     end
                 end
             elseif (source == aTab4.UnbanIP) then
@@ -1328,13 +1315,13 @@ function aClientClick(button)
             elseif (source == aTab6.PasswordChange) then
                 local passwordNew, passwordConf = guiGetText(aTab6.PasswordNew), guiGetText(aTab6.PasswordConfirm)
                 if (passwordNew == "") then
-                    aMessageBox("error", "Enter the new password")
+                    messageBox("Enter the new password", MB_ERROR, MB_OK)
                 elseif (passwordConf == "") then
-                    aMessageBox("error", "Confirm the new password")
+                    messageBox("Confirm the new password", MB_ERROR, MB_OK)
                 elseif (string.len(passwordNew) < 4) then
-                    aMessageBox("error", "The new password must be at least 4 characters long")
+                    messageBox("The new password must be at least 4 characters long", MB_ERROR, MB_OK)
                 elseif (passwordNew ~= passwordConf) then
-                    aMessageBox("error", "Confirmed password doesn't match")
+                    messageBox("Confirmed password doesn't match", MB_ERROR, MB_OK)
                 else
                     triggerServerEvent(
                         "aAdmin",

--- a/[admin]/admin2/client/widgets/admin_acl.lua
+++ b/[admin]/admin2/client/widgets/admin_acl.lua
@@ -222,19 +222,13 @@ function aClientACLClick(button)
                 'triggerServerEvent ( "aAdmin", getLocalPlayer(), "aclcreate", "acl", $value )'
             )
         elseif (source == aACLDestroyGroup) then
-            aMessageBox(
-                "warning",
-                "Are you sure to destroy " .. aAclData["current"] .. " group?",
-                'triggerServerEvent ( "aAdmin", getLocalPlayer(), "acldestroy", "group", "' ..
-                    aAclData["current"] .. '" )'
-            )
+            if (messageBox("Are you sure to destroy " .. aAclData["current"] .. " group?", MB_WARNING, MB_YESNO) == true) then
+                triggerServerEvent ( "aAdmin", getLocalPlayer(), "acldestroy", "group", aAclData["current"] )
+            end
         elseif (source == aACLDestroyACL) then
-            aMessageBox(
-                "warning",
-                "Are you sure to destroy " .. aAclData["current"] .. " ACL?",
-                'triggerServerEvent ( "aAdmin", getLocalPlayer(), "acldestroy", "acl", "' ..
-                    aAclData["current"] .. '" )'
-            )
+            if (messageBox("Are you sure to destroy " .. aAclData["current"] .. " ACL?", MB_WARNING, MB_YESNO) == true) then
+                triggerServerEvent ( "aAdmin", getLocalPlayer(), "acldestroy", "acl", aAclData["current"] )
+            end
         elseif ((source == aACLRemoveObject) or (source == aACLAddACL) or (source == aACLRemoveACL)) then
             guiSetVisible(aACLAddObject, false)
             guiSetVisible(aACLRemoveObject, false)

--- a/[admin]/admin2/client/widgets/admin_messages.lua
+++ b/[admin]/admin2/client/widgets/admin_messages.lua
@@ -100,7 +100,7 @@ function aMessages.onClick(button)
         elseif (source == aMessages.Read) then
             local row = guiGridListGetSelectedItem(aMessages.List)
             if (row == -1) then
-                aMessageBox("Warning", "No message selected!", nil)
+                messageBox("No message selected!", MB_WARNING, MB_OK)
             else
                 local id = guiGridListGetItemText(aMessages.List, row, 1)
                 aViewMessage(tonumber(id))
@@ -108,7 +108,7 @@ function aMessages.onClick(button)
         elseif (source == aMessages.Delete) then
             local row = guiGridListGetSelectedItem(aMessages.List)
             if (row == -1) then
-                aMessageBox("Warning", "No message selected!")
+                messageBox("No message selected!", MB_WARNING, MB_OK)
             else
                 local id = guiGridListGetItemText(aMessages.List, row, 1)
                 triggerServerEvent("aMessage", getLocalPlayer(), "delete", tonumber(id))

--- a/[admin]/admin2/client/widgets/admin_spectator.lua
+++ b/[admin]/admin2/client/widgets/admin_spectator.lua
@@ -190,7 +190,10 @@ function aSpectator.SwitchPlayer(inc, arg, inc2)
         players = getElementsByType("player")
     end
     if (#players <= 0) then
-        aMessageBox("question", "Nobody to spectate, exit spectator?", "aSpectator.Close ( false )")
+        if (messageBox("Nobody else to spectate, exit spectator?", 1, 1) == true) then
+            aSpectator.Close(false)
+            aAdminMain.Open()
+        end
         return
     end
     local current = 1
@@ -201,7 +204,10 @@ function aSpectator.SwitchPlayer(inc, arg, inc2)
     end
     local next = ((current - 1 + inc) % #players) + 1
     if (next == current) then
-        aMessageBox("question", "Nobody else to spectate, exit spectator?", "aSpectator.Close ( false )")
+        if (messageBox("Nobody else to spectate, exit spectator?", 1, 1) == true) then
+            aSpectator.Close(false)
+            aAdminMain.Open()
+        end
         return
     end
     aSpectator.Spectating = players[next]

--- a/[admin]/admin2/client/widgets/admin_stats.lua
+++ b/[admin]/admin2/client/widgets/admin_stats.lua
@@ -102,7 +102,7 @@ function aClientStatsClick(button)
                     if ((value) and (value >= 0) and (value <= 1000)) then
                         triggerServerEvent("aPlayer", getLocalPlayer(), aStatsSelect, "setstat", id, value)
                     else
-                        aMessageBox("error", "Not numerical value (0-1000)")
+                        messageBox("Not numerical value (0-1000)", MB_ERROR, MB_OK)
                     end
                     return
                 end
@@ -136,7 +136,7 @@ function aClientStatsAccepted()
             if ((value) and (value >= 0) and (value <= 1000)) then
                 triggerServerEvent("aPlayer", getLocalPlayer(), aStatsSelect, "setstat", id, value)
             else
-                aMessageBox("error", "Not numerical value (0-1000)")
+                messageBox("Not numerical value (0-1000)", MB_ERROR, MB_OK)
             end
             return
         end


### PR DESCRIPTION
Fix for https://github.com/multitheftauto/mtasa-resources/issues/171
admin2 still uses admin1's messageBox format.
Scripts now use messageBox correctly.
```aMessageBox()``` calls are now using the correct function ```messageBox()```.
Usage of coroutines instead of actions passed as arguments.