### PR TITLE
admin2: new shutdown reason behaviour

### DIFF
--- a/[admin]/admin2/client/main/admin_server.lua
+++ b/[admin]/admin2/client/main/admin_server.lua
@@ -191,9 +191,8 @@ function aServerTab.onClientClick(button)
                 triggerServerEvent("aServer", getLocalPlayer(), "setpassword", "")
             end
         elseif (source == aServerTab.Shutdown) then
-            local reason = inputBox("Shutdown", "Enter shut down reason:")
-            if (reason) then
-                triggerServerEvent("aServer", getLocalPlayer(), "shutdown", reason)
+            if (messageBox("Are you sure you want to shutdown the server?", MB_QUESTION, MB_YESNO )) then
+                triggerServerEvent("aServer", getLocalPlayer(), "shutdown")
             end
         elseif (source == aServerTab.ClearChat) then
             triggerServerEvent("aServer", getLocalPlayer(), "clearchat", "")

--- a/[admin]/admin2/server/admin_functions.lua
+++ b/[admin]/admin2/server/admin_functions.lua
@@ -467,8 +467,8 @@ aFunctions = {
                 return false
             end
         end,
-        ["shutdown"] = function(reason)
-            shutdown(iif(reason, tostring(reason), nil))
+        ["shutdown"] = function()
+            shutdown("triggered by "..getPlayerName(source))
         end,
         ["clearchat"] = function()
             clearChatBox()


### PR DESCRIPTION
This PR changes the shutdown function of admin2 in two ways:

1. The reason input has been replaced with a confirmation dialog
2. The shutdown reason is generated by the server using the following format:
`Server shutdown as requested by resource admin2 (triggered by [player name])`

I think this is the best solution because:

1. In my experience, admins rarely (if ever) enter a shutdown reason 
2. This method ensures there is always a record of _who_ shut the server down (previously, there was no such record)