### PR TITLE
runcode: fix HTTP callback `httpRun` not checking for permissions

### DIFF
--- a/[admin]/runcode/server.lua
+++ b/[admin]/runcode/server.lua
@@ -79,6 +79,15 @@ addCommandHandler("crun",
 -- http interface run export
 function httpRun(commandstring)
 	if not user then outputDebugString ( "httpRun can only be called via http", 2 ) return end
+	
+	-- check acl permission
+	local objectName = "user." .. getAccountName(user)
+	
+	if(not hasObjectPermissionTo(objectName, "command.srun", false)) then
+		outputDebugString("httpRun: Permission denied")
+		return "Error: Permission denied"
+	end
+	
 	local notReturned
 	--First we test with return
 	local commandFunction,errorMsg = loadstring("return "..commandstring)

--- a/[admin]/runcode/server.lua
+++ b/[admin]/runcode/server.lua
@@ -84,7 +84,6 @@ function httpRun(commandstring)
 	local objectName = "user." .. getAccountName(user)
 	
 	if(not hasObjectPermissionTo(objectName, "command.srun", false)) then
-		outputDebugString("httpRun: Permission denied")
 		return "Error: Permission denied"
 	end
 	


### PR DESCRIPTION
Previously, runcode never checked for the right permissions leading to a security vulnerability.
This patch however fixes that by simply checking if the loggedin user has permissions to `command.srun`.

- LuX