### PR TITLE
admin: fix setinterior command spec

### DIFF
--- a/[admin]/admin/conf/commands.xml
+++ b/[admin]/admin/conf/commands.xml
@@ -19,7 +19,7 @@
     <command handler="setskin" call="setskin" args="P,i" />
     <command handler="setstat" call="setstat" args="P,i,i" />
     <command handler="setteam" call="setteam" args="P,T" />
-    <command handler="setinterior" call="setinterior" args="P,i" />
+    <command handler="setinterior" call="setinterior" args="P,s" />
     <command handler="setdimension" call="setdimension" args="P,i" />
     <command handler="jetpack" call="jetpack" args="P" />
     <command handler="givevehicle" call="givevehicle" args="P,i" />


### PR DESCRIPTION
Command /setinterior should only accept string as 2nd argument because of interiors.xml. It's not like setElementInterior that only accepts integer.