### PR TITLE
runcode: add "watch variables" feature

### DIFF
--- a/[admin]/runcode/client.lua
+++ b/[admin]/runcode/client.lua
@@ -1,12 +1,5 @@
 me = localPlayer
 
-local watch
-
-runcode = {
-	me = localPlayer,
-	watch = watch
-}
-
 -- Primary functionality
 local function runString (commandstring)
 	outputChatBoxR("Executing client-side command: "..commandstring)
@@ -72,7 +65,7 @@ local function watchRender()
 	end
 end
 
-function watch(key, v)
+local function watch(key, v)
 	-- Error checking
 	if type(v) ~= "string" and type(v) ~= "function" and type(v) ~= "nil" then
 		error("Unexpected watch value of type " .. type(v) .. " for key " .. key)
@@ -111,3 +104,8 @@ function watch(key, v)
 		addEventHandler("onClientRender", root, watchRender)
 	end
 end
+
+runcode = {
+	me = localPlayer,
+	watch = watch
+}

--- a/[admin]/runcode/shared_util.lua
+++ b/[admin]/runcode/shared_util.lua
@@ -8,3 +8,11 @@ _players = setmetatable({}, {
     -- Disable setting of items in _players
     __newindex = function() end,
 })
+
+function table.find(t, needle)
+    for i, val in pairs(t) do
+        if val == needle then
+            return i
+        end
+    end
+end


### PR DESCRIPTION
Makes it possible to watch variables easier.

Please review! (if you merge for me, please don't forget to squash)

**Screenshot**

![image](https://user-images.githubusercontent.com/923242/76164855-12da6c00-614a-11ea-8773-c3af5d8fd363.png)

**Usage**

Below are lines that you can run via `crun`.

```lua
-- Watch results of function
runcode.watch("cam", getCameraMatrix)

-- Watch results of runcode global
runcode.watch("global test", "kek")
kek = 9

-- Remove "global test"
runcode.watch("global test", nil)
```

**Enhancements for a future PR**

Might want to move the renders to below chat (pinned to left), rather than bottom right corner (pinned to right).