### PR TITLE
editor: Add OOP support for editor_test map

### DIFF
--- a/[editor]/editor_main/server/dumpxml.lua
+++ b/[editor]/editor_main/server/dumpxml.lua
@@ -79,6 +79,11 @@ function dumpMeta ( xml, extraNodes, resource, filename, test )
 	if not resource then return false end
 	dimension = dimension or 0
 	extraNodes = extraNodes or {}
+
+	--Add OOP support
+	local oopNode = xmlCreateChild(xml, "oop")
+	xmlNodeSetValue(oopNode, "true")
+
 	--[[ info tag ]]--
 	local infoNode = xmlCreateChild(xml, "info")
 


### PR DESCRIPTION
Heyo!

I've recently gotten back into MTA and am already a big fan of the OOP-syntax - sadly when creating maps in the editor said OOP-syntax isn't working...

After looking around the files a bit I noticed that the `editor_test` map it generates (more specifically the `meta.xml` for it) doesn't include the `<oop>true</oop>` node.

This PR fixes that.

Seeing as the old methods are still working even if this is on I don't see it as a downside at all - quite the contrary, it's only beneficial to those that want to use that new syntax! :)