### PR TITLE
editor: Clear oop node before saving

### DIFF
--- a/[editor]/editor_main/server/resourcehooks.lua
+++ b/[editor]/editor_main/server/resourcehooks.lua
@@ -54,6 +54,15 @@ function clearResourceMeta ( resource, quick ) --removes settings and info nodes
 			break
 		end
 	end
+	--Destroy leftover OOP nodes
+	while true do
+		local oopNode = xmlFindChild(metaNode, 'oop', 0)
+		if oopNode then
+			xmlDestroyNode(oopNode)
+		else
+			break
+		end
+	end
 	--Destroy any other nodes
 	local nodes = xmlNodeGetChildren ( metaNode )
 	for key, node in ipairs(nodes) do


### PR DESCRIPTION
This is so it won't add several of the same node into the meta.xml file.

Sorry for not noticing this initially!