### PR TITLE
votemanager: added additional resource settings for ban votes

### DIFF
--- a/[managers]/votemanager/meta.xml
+++ b/[managers]/votemanager/meta.xml
@@ -48,9 +48,9 @@
 		<setting name="*voteban_locktime" value="[120]"/>
 		<setting name="*voteban_percentage" value="[75]"/>
 		<setting name="*voteban_allowchange" value="[true]"/>
-		<setting name="*voteban_banip" value="[true]"/>
+		<setting name="*voteban_banip" value="[false]"/>
 		<setting name="*voteban_banusername" value="[false]"/>
-		<setting name="*voteban_banserial" value="[false]"/>
+		<setting name="*voteban_banserial" value="[true]"/>
 		<setting name="*voteban_duration" value="[3600]"/>
 
 		<setting name="*votekill_enabled" value="[false]"/>

--- a/[managers]/votemanager/meta.xml
+++ b/[managers]/votemanager/meta.xml
@@ -48,6 +48,10 @@
 		<setting name="*voteban_locktime" value="[120]"/>
 		<setting name="*voteban_percentage" value="[75]"/>
 		<setting name="*voteban_allowchange" value="[true]"/>
+		<setting name="*voteban_banip" value="[true]"/>
+		<setting name="*voteban_banusername" value="[false]"/>
+		<setting name="*voteban_banserial" value="[false]"/>
+		<setting name="*voteban_duration" value="[3600]"/>
 
 		<setting name="*votekill_enabled" value="[false]"/>
 		<setting name="*votekill_timeout" value="[15]"/>

--- a/[managers]/votemanager/votemanager_polls.lua
+++ b/[managers]/votemanager/votemanager_polls.lua
@@ -58,6 +58,12 @@ addEventHandler("onResourceStart", thisResourceRoot,
 			info.percentage  = get(settingsGroup.."_percentage") or nil
 			info.timeout     = get(settingsGroup.."_timeout")    or nil
 			info.allowchange = get(settingsGroup.."_allowchange")
+			if name == "ban" then
+				info.banip       = get(settingsGroup.."_banip")
+				info.banusername = get(settingsGroup.."_banusername")
+				info.banserial   = get(settingsGroup.."_banserial")
+				info.duration    = get(settingsGroup.."_duration")
+			end
 			info.blockedPlayers = {}
 			addCommandHandler("vote"..name, vote[name].handler )
 		end
@@ -457,7 +463,7 @@ function voteBan(player, reason)
 			visibleTo = rootElement,
 			timeout = vote.ban.timeout,
 			allowchange = vote.ban.allowchange;
-			[1]={"Yes",banPlayer,player,serverConsole,reason},
+			[1]={"Yes",banPlayer,player,vote.ban.banip,vote.ban.banusername,vote.ban.banserial,serverConsole,reason,vote.ban.duration},
 			[2]={"No",outputVoteManager,"voteban: not enough votes to ban "..getPlayerName(player)..".",rootElement,vR,vG,vB;default=true},
 		}
 	end

--- a/[managers]/votemanager/votemanager_polls.lua
+++ b/[managers]/votemanager/votemanager_polls.lua
@@ -476,8 +476,6 @@ function voteKill(player, reason)
 		local title = "Kill "..getPlayerName(player).."?"
 		if reason then
 			title = title.." ("..reason..")"
-		else
-			reason = ""
 		end
 		return startPoll{
 			title=title,

--- a/[managers]/votemanager/votemanager_polls.lua
+++ b/[managers]/votemanager/votemanager_polls.lua
@@ -426,6 +426,8 @@ function voteKick(player, reason)
 		local title = "Kick "..getPlayerName(player).."?"
 		if reason then
 			title = title.." ("..reason..")"
+		else
+			reason = ""
 		end
 		return startPoll{
 			title=title,
@@ -446,6 +448,8 @@ function voteBan(player, reason)
 		local title = "Ban "..getPlayerName(player).."?"
 		if reason then
 			title = title.." ("..reason..")"
+		else
+			reason = ""
 		end
 		return startPoll{
 			title=title,
@@ -466,6 +470,8 @@ function voteKill(player, reason)
 		local title = "Kill "..getPlayerName(player).."?"
 		if reason then
 			title = title.." ("..reason..")"
+		else
+			reason = ""
 		end
 		return startPoll{
 			title=title,


### PR DESCRIPTION
banPlayer provides a lot of banning options, none of which votemanager currently supports changing for its ban votes. This commit adds the following settings to the resource: 

1. voteban_banip true/false (default: true);
2. voteban_banusername true/false (default: false);
3. voteban_banserial true/false (default: false);
4. voteban_duration number in seconds (default: 3600)

Default values are the same as the default within banPlayer, except for duration, which is 1 hour instead of infinite. Note that voteban_enabled default remains false just as before.

The addition of the empty reason string when no reason is supplied via command is a workaround to avoid issues with lua's unpack() when unpacking tables containing nil entries. Here's an example: `local tab = {true,false,false,nil,5} tab.cheese = "Yes" local a,b,c,d,e = unpack (tab) outputChatBox(tostring(e))` should output 5 but instead outputs nil. Without the modification `tab.cheese = "Yes"` it will correctly output 5. Meanwhile directly referencing it without unpack always seems to be working as intended `local tab = {true,false,false,nil,5} tab.cheese = "Yes" local a,b,c,d,e = unpack (tab) outputChatBox(tostring(tab[5]))` outputting 5 correctly. Unless banPlayer internally handles an empty string very differently to nil I don't see any major drawbacks with this. I can't think of any better workaround, as votemanager relies on further modifying the tables and unpack() to read from them. But maybe someone else has a good idea.

Lastly note that votekicks weren't functional before and will not be before https://github.com/multitheftauto/mtasa-blue/issues/1301 gets resolved.