### PR TITLE
freeroam: fix exploit to get around hex code removal

### DIFF
--- a/[gameplay]/freeroam/fr_server.lua
+++ b/[gameplay]/freeroam/fr_server.lua
@@ -443,7 +443,10 @@ addEventHandler('onPlayerChat', root,
 			end
 			if isElement(source) then
 				local r, g, b = getPlayerNametagColor(source)
-				outputChatBox(getPlayerName(source) .. ': #FFFFFF' .. msg:gsub('#%x%x%x%x%x%x', ''), root, r, g, b, true)
+				while(msg:gsub('#%x%x%x%x%x%x', ''):len() ~= msg:len()) do
+					msg = msg:gsub('#%x%x%x%x%x%x', '')
+				end
+				outputChatBox(getPlayerName(source) .. ': #FFFFFF' .. msg, root, r, g, b, true)
 				outputServerLog( "CHAT: " .. getPlayerName(source) .. ": " .. msg )
 			end
 		end

--- a/[gameplay]/freeroam/fr_server.lua
+++ b/[gameplay]/freeroam/fr_server.lua
@@ -443,10 +443,7 @@ addEventHandler('onPlayerChat', root,
 			end
 			if isElement(source) then
 				local r, g, b = getPlayerNametagColor(source)
-				while(msg:gsub('#%x%x%x%x%x%x', ''):len() ~= msg:len()) do
-					msg = msg:gsub('#%x%x%x%x%x%x', '')
-				end
-				outputChatBox(getPlayerName(source) .. ': #FFFFFF' .. msg, root, r, g, b, true)
+				outputChatBox(getPlayerName(source) .. ': #FFFFFF' .. stripHex(msg), root, r, g, b, true)
 				outputServerLog( "CHAT: " .. getPlayerName(source) .. ": " .. msg )
 			end
 		end

--- a/[gameplay]/freeroam/util_server.lua
+++ b/[gameplay]/freeroam/util_server.lua
@@ -17,6 +17,15 @@ function errMsg(msg, player)
 	outputChatBox(msg, player or root, 255, 0, 0)
 end
 
+function stripHex(str)
+    local oldLen
+    repeat
+        oldLen = str:len()
+        str = str:gsub('#%x%x%x%x%x%x', '')
+    until str:len() == oldLen
+    return str
+end
+
 function table.find(t, ...)
 	local args = { ... }
 	if #args == 0 then


### PR DESCRIPTION
For a long time it has been possible to avoid hex removal from a message in Freeroam. This PR fixes the problem.

The following message:
#00ff00color #00ff#ffffff00code

"color" would have it's hex code removed, and so would "code", but after removal of one hex code on word "code", it would join together as #00ff00code and thus the hex removal was avoided.

My apologies on description though. This PR makes sure that there can be no hex code present in player's message and fixes the earlier abuse problem.