### PR TITLE
runcode: add logging to `crun` and http

### DIFF
--- a/[admin]/runcode/server.lua
+++ b/[admin]/runcode/server.lua
@@ -69,6 +69,7 @@ addCommandHandler("crun",
 	function (player, command, ...)
 		local commandstring = table.concat({...}, " ")
 		if player then
+			outputChatBoxR(getPlayerName(player) .. " executed client-side command: " .. commandstring, false)
 			return triggerClientEvent(player, "doCrun", rootElement, commandstring)
 		else
 			return runString(commandstring, false, false)
@@ -81,7 +82,8 @@ function httpRun(commandstring)
 	if not user then outputDebugString ( "httpRun can only be called via http", 2 ) return end
 
 	-- check acl permission
-	local objectName = "user." .. getAccountName(user)
+	local accName = getAccountName(user)
+	local objectName = "user." .. accName
 
 	if(not hasObjectPermissionTo(objectName, "command.srun", false)) then
 		outputServerLog(getAccountName(user) .. " from " .. hostname .. " attempted to execute Lua code with missing acl permission (command.srun)")
@@ -106,6 +108,9 @@ function httpRun(commandstring)
 		--It failed.
 		return "Error: "..results[2]
 	end
+
+	outputChatBoxR("[HTTP] " .. accName .. " from " .. hostname .. " executed command: " .. commandstring, false)
+
 	if not notReturned then
 		local resultsString = ""
 		local first = true


### PR DESCRIPTION
This PR resolves #180 by adding logging to commands executed by `/crun` & `httpRun`.