### PR TITLE
Fix min_mta_version warning in missiontimer

### DIFF
--- a/[gameplay]/missiontimer/meta.xml
+++ b/[gameplay]/missiontimer/meta.xml
@@ -1,5 +1,7 @@
 <meta>
 	<info author="Talidan" version="1.0.0" description="Utility script to handle mission timers for scripts" />
+	<min_mta_version server="1.3.0-9.04570"/>
+	
 	<script src="missiontimer_server.lua" type="server" />
 	<script src="missiontimer_client.lua" type="client" />
 	<script src="missiontimer_rpc.lua" type="client" />


### PR DESCRIPTION
This PR fixes the following warning in missiontimer (used by a few of the default gamemodes):

`WARNING: [mtasa-resources]\[gameplay]\missiontimer\missiontimer_server.lua:29: <min_mta_version> section in the meta.xml is incorrect or missing (expected at least server 1.3.0-9.04570 because a send list is being used)`