### PR TITLE
race: Change the start of countdown from 6 to 3

### DIFF
--- a/[gamemodes]/[race]/race/race_server.lua
+++ b/[gamemodes]/[race]/race/race_server.lua
@@ -358,7 +358,7 @@ function launchRace()
     gotoState('Running')
 end
 
-g_RaceStartCountdown = Countdown.create(6, launchRace)
+g_RaceStartCountdown = Countdown.create(3, launchRace)
 g_RaceStartCountdown:useImages('img/countdown_%d.png', 474, 204)
 g_RaceStartCountdown:enableFade(true)
 g_RaceStartCountdown:addClientHook(3, 'playSoundFrontEnd', 44)


### PR DESCRIPTION
Fixes #214 
btw i didn't find any clue why it's 6 seconds maybe a mistake?
i couldn't find any images to 4,5,6 in old versions, 
even the code it plays a sound 4 times instead of 6
`g_RaceStartCountdown:addClientHook(3, 'playSoundFrontEnd', 44)
g_RaceStartCountdown:addClientHook(2, 'playSoundFrontEnd', 44)
g_RaceStartCountdown:addClientHook(1, 'playSoundFrontEnd', 44)
g_RaceStartCountdown:addClientHook(0, 'playSoundFrontEnd', 45)`