### PR TITLE
playercolors: fix colors resetting when map is unloaded by mapmanager

### DIFF
--- a/[gameplay]/playercolors/playercolors.lua
+++ b/[gameplay]/playercolors/playercolors.lua
@@ -1,8 +1,6 @@
 local lowerBound,upperBound = unpack(get"color_range")
-g_Root = getRootElement ()
-g_ResourceRoot = getResourceRootElement ( getThisResource () )
 
-addEventHandler ( "onResourceStart", g_ResourceRoot,
+addEventHandler ( "onResourceStart", resourceRoot,
 	function()
 		for i,player in ipairs(getElementsByType"player") do
 			processPlayer ( player )
@@ -15,17 +13,17 @@ function processPlayer ( player )
 	local r, g, b = math.random(lowerBound, upperBound), math.random(lowerBound, upperBound), math.random(lowerBound, upperBound)
 	setPlayerNametagColor(player, r, g, b)
 end
-addEventHandler ( "onPlayerJoin", g_Root, processPlayer )
+addEventHandler ( "onPlayerJoin", root, processPlayer )
 
 
-addEventHandler('onPlayerChat', g_Root,
+addEventHandler('onPlayerChat', root,
 	function(msg, type)
 		if type == 0 then
 			cancelEvent()
 			local r, g, b = getPlayerColor(source)
 			local name = getPlayerName(source)
 			local msg = msg:gsub('#%x%x%x%x%x%x', '')
-			outputChatBox( name.. ': #FFFFFF' .. msg, g_Root, r, g, b, true)
+			outputChatBox( name.. ': #FFFFFF' .. msg, root, r, g, b, true)
 			outputServerLog( "CHAT: " .. name .. ": " .. msg )
 		end
 	end

--- a/[gameplay]/playercolors/playercolors.lua
+++ b/[gameplay]/playercolors/playercolors.lua
@@ -1,20 +1,19 @@
-local lowerBound,upperBound = unpack(get"color_range")
+local lowerBound, upperBound = unpack(get("color_range"))
 
-addEventHandler ( "onResourceStart", resourceRoot,
-	function()
-		for i,player in ipairs(getElementsByType"player") do
-			processPlayer ( player )
-		end
-	end
-)
-
-function processPlayer ( player )
+function randomizePlayerColor(player)
 	player = player or source
 	local r, g, b = math.random(lowerBound, upperBound), math.random(lowerBound, upperBound), math.random(lowerBound, upperBound)
 	setPlayerNametagColor(player, r, g, b)
 end
-addEventHandler ( "onPlayerJoin", root, processPlayer )
+addEventHandler("onPlayerJoin", root, randomizePlayerColor)
 
+local function randomizeAllPlayerColors()
+	for _, player in ipairs(getElementsByType("player")) do
+		randomizePlayerColor(player)
+	end
+end
+addEventHandler("onResourceStart", resourceRoot, randomizeAllPlayerColors)
+addEventHandler("onGamemodeMapStart", root, randomizeAllPlayerColors) -- mapmanager resets player colors to white when the map ends
 
 addEventHandler('onPlayerChat', root,
 	function(msg, type)


### PR DESCRIPTION
When merged, this PR will fix a bug where playercolors default back to white when a map is unloaded by mapmanager. It also makes minor code quality improvements.