### PR TITLE
Fix for #175

### DIFF
--- a/[editor]/editor_main/client/main.lua
+++ b/[editor]/editor_main/client/main.lua
@@ -637,8 +637,8 @@ end
 
 function requiresObjectCollisions(element)
 	for k, child in ipairs(getElementChildren(element)) do
-		if getElementData(child, "edf:dummy") == false then
-			if getElementData(child, "edf:rep") == true then
+		if not getElementData(child, "edf:dummy") then
+			if getElementData(child, "edf:rep") then
 				if getElementType(child) ~= "object" then
 					return false
 				end

--- a/[editor]/editor_main/client/main.lua
+++ b/[editor]/editor_main/client/main.lua
@@ -638,14 +638,15 @@ end
 function requiresObjectCollisions(element)
 	for k, child in ipairs(getElementChildren(element)) do
 		if getElementData(child, "edf:dummy") == false then
-			if getElementType(child) ~= 'object' then
-				return false
+			if getElementData(child, "edf:rep") == true then
+				if getElementType(child) ~= "object" then
+					return false
+				end
 			end
 		end
 	end
 	return true
 end
-
 
 -- Drag and drop
 function processCursorMove(cursorX, cursorY, absoluteX, absoluteY, worldX, worldY, worldZ)

--- a/[editor]/editor_main/client/main.lua
+++ b/[editor]/editor_main/client/main.lua
@@ -635,6 +635,18 @@ function setRepresentationCollisionsEnabled(element, state)
 	end
 end
 
+function requiresObjectCollisions(element)
+	for k, child in ipairs(getElementChildren(element)) do
+		if getElementData(child, "edf:dummy") == false then
+			if getElementType(child) ~= 'object' then
+				return false
+			end
+		end
+	end
+	return true
+end
+
+
 -- Drag and drop
 function processCursorMove(cursorX, cursorY, absoluteX, absoluteY, worldX, worldY, worldZ)
 	if g_dragElement then
@@ -758,7 +770,9 @@ function selectElement(element, submode, shortcut, dropreleaseLock, dropclonedro
 	assert(handle == nil or isElement(handle), "Bad handle ["..tostring(handle).."] for element: "..getElementType(element))
 
 	-- temporarily disable collisions for all parts
-	setRepresentationCollisionsEnabled(element, false)
+	if not requiresObjectCollisions(element) then
+		setRepresentationCollisionsEnabled(element, false)
+	end
 
 	-- if we can position this element, grab it and add the markers
 	if handle then


### PR DESCRIPTION
Fixes #175 , the only solution that I could come up with for this issue that most likely won't break anything. (As I don't know in which cases it might be necessary to remove collisions for an elements representations)

It now iterates through the elements children and only disables the collisions if it has a representation that is not an object.