### PR TITLE
editor: replace 1729ceb (#219) with a better fix

### DIFF
--- a/[editor]/editor_main/client/main.lua
+++ b/[editor]/editor_main/client/main.lua
@@ -635,19 +635,6 @@ function setRepresentationCollisionsEnabled(element, state)
 	end
 end
 
-function requiresObjectCollisions(element)
-	for k, child in ipairs(getElementChildren(element)) do
-		if not getElementData(child, "edf:dummy") then
-			if getElementData(child, "edf:rep") then
-				if getElementType(child) ~= "object" then
-					return false
-				end
-			end
-		end
-	end
-	return true
-end
-
 -- Drag and drop
 function processCursorMove(cursorX, cursorY, absoluteX, absoluteY, worldX, worldY, worldZ)
 	if g_dragElement then
@@ -770,11 +757,6 @@ function selectElement(element, submode, shortcut, dropreleaseLock, dropclonedro
 
 	assert(handle == nil or isElement(handle), "Bad handle ["..tostring(handle).."] for element: "..getElementType(element))
 
-	-- temporarily disable collisions for all parts
-	if not requiresObjectCollisions(element) then
-		setRepresentationCollisionsEnabled(element, false)
-	end
-
 	-- if we can position this element, grab it and add the markers
 	if handle then
 		local move_resource
@@ -785,6 +767,8 @@ function selectElement(element, submode, shortcut, dropreleaseLock, dropclonedro
 				move_resource = move_cursor
 			end
 			move_resource.setMaxMoveDistance(g_moveDistance)
+			-- if we're dragging the object, disable collisions for all parts so the cursor can point through it
+			setRepresentationCollisionsEnabled(element, false)
 		elseif (submode == KEYBOARD_SUBMODE) then
 			move_resource = move_keyboard
 		else


### PR DESCRIPTION
When dragging the representation the cursor could point at it which would result in the object moving away from itself.
For whatever reason I didn't come across this when  testing.
_And now I know why the collisions are  being disabled._

So here's a better fix that only disables the collisions when the element is being dragged.