### PR TITLE
race: Add ghost mode transparency amount setting

### DIFF
--- a/[gamemodes]/[race]/race/meta.xml
+++ b/[gamemodes]/[race]/race/meta.xml
@@ -145,6 +145,13 @@
 					desc="Set to true to make vehicle semi-transparent when collisions are disabled."
 					/>
 
+		<setting name="*ghostalphalevel" value="180"
+					friendlyname="Ghost alpha level"
+					accept="0-255"
+					group="Graphics"
+					desc="Amount of transparency when collisions are disabled. Acceptable values are from 0 (fully transparent) to 255 (fully opaque)."
+					/>
+
         <setting name="*randommaps" value="false"
 					friendlyname="Random maps"
 					accept="false,true"

--- a/[gamemodes]/[race]/race/modes/base.lua
+++ b/[gamemodes]/[race]/race/modes/base.lua
@@ -489,7 +489,7 @@ function RaceMode.playerFreeze(player, bRespawn, bDontFix)
 
 	-- Setup ghost mode for this vehicle
 	Override.setCollideOthers( "ForGhostCollisions", vehicle, g_MapOptions.ghostmode and 0 or nil )
-	Override.setAlpha( "ForGhostAlpha", {player, vehicle}, g_MapOptions.ghostmode and g_GameOptions.ghostalpha and 180 or nil )
+	Override.setAlpha( "ForGhostAlpha", {player, vehicle}, g_MapOptions.ghostmode and g_GameOptions.ghostalpha and g_GameOptions.ghostalphalevel or nil )
 
 	-- Show non-ghost vehicles as semi-transparent while respawning
 	Override.setAlpha( "ForRespawnEffect", {player, vehicle}, bRespawn and not g_MapOptions.ghostmode and 120 or nil )

--- a/[gamemodes]/[race]/race/race_server.lua
+++ b/[gamemodes]/[race]/race/race_server.lua
@@ -91,6 +91,7 @@ function cacheGameOptions()
 	g_GameOptions.defaultduration		= getNumber('race.duration',6000) * 1000
 	g_GameOptions.ghostmode				= getBool('race.ghostmode',false)
 	g_GameOptions.ghostalpha			= getBool('race.ghostalpha',false)
+	g_GameOptions.ghostalphalevel		= getNumber('race.ghostalphalevel',180)
 	g_GameOptions.randommaps			= getBool('race.randommaps',false)
 	g_GameOptions.statskey				= getString('race.statskey','name')
 	g_GameOptions.vehiclecolors			= getString('race.vehiclecolors','file')
@@ -909,7 +910,7 @@ function updateGhostmode()
 		local vehicle = RaceMode.getPlayerVehicle(player)
 		if vehicle then
 			Override.setCollideOthers( "ForGhostCollisions", vehicle, g_MapOptions.ghostmode and 0 or nil )
-			Override.setAlpha( "ForGhostAlpha", {player, vehicle}, g_MapOptions.ghostmode and g_GameOptions.ghostalpha and 180 or nil )
+			Override.setAlpha( "ForGhostAlpha", {player, vehicle}, g_MapOptions.ghostmode and g_GameOptions.ghostalpha and g_GameOptions.ghostalphalevel or nil )
 		end
 	end
 end


### PR DESCRIPTION
Resolves https://github.com/multitheftauto/mtasa-resources/issues/187
Add `ghostalphalevel` setting to race to control ghost mode transparency.