### PR TITLE
freeroam: Fix warning when time is set to freeze

### DIFF
--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -1871,14 +1871,16 @@ addCommandHandler('st', setTimeCommand)
 function toggleFreezeTime()
 	local state = guiCheckBoxGetSelected(getControl(wndMain, 'freezetime'))
 	guiCheckBoxSetSelected(getControl(wndMain, 'freezetime'), not state)
-	setTimeFrozen(state)
+	local h, m = getTime()
+	local w = getWeather()
+	setTimeFrozen(state, h, m, w)
 end
 
 function setTimeFrozen(state, h, m, w)
 	guiCheckBoxSetSelected(getControl(wndMain, 'freezetime'), state)
 	if state then
 		if not g_TimeFreezeTimer then
-			g_TimeFreezeTimer = setTimer(function() setTime(h, m) setWeather(w) end, 5000, 0)
+			g_TimeFreezeTimer = setTimer(function(h, m, w) setTime(h, m) setWeather(w) end, 5000, 0, h, m, w)
 			setMinuteDuration(9001)
 		end
 	else

--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -40,6 +40,11 @@ if not (g_PlayerData) then
     g_PlayerData = {}
 end
 
+-- Variables for time freeze
+local freezeTimeHour = false
+local freezeTimeMinute = false
+local freezeTimeWeather = false
+
 -- Settings are stored in meta.xml
 function freeroamSettings(settings)
 	if settings then
@@ -1820,6 +1825,7 @@ function applyTime()
 	local hours, minutes = getControlNumbers(wndTime, { 'hours', 'minutes' })
 	setTime(hours, minutes)
 	closeWindow(wndTime)
+	freezeTimeHour, freezeTimeMinute = hours, minutes
 end
 
 wndTime = {
@@ -1871,16 +1877,16 @@ addCommandHandler('st', setTimeCommand)
 function toggleFreezeTime()
 	local state = guiCheckBoxGetSelected(getControl(wndMain, 'freezetime'))
 	guiCheckBoxSetSelected(getControl(wndMain, 'freezetime'), not state)
-	local h, m = getTime()
-	local w = getWeather()
-	setTimeFrozen(state, h, m, w)
+	freezeTimeHour, freezeTimeMinute = getTime()
+	freezeTimeWeather = getWeather()
+	setTimeFrozen(state)
 end
 
-function setTimeFrozen(state, h, m, w)
+function setTimeFrozen(state)
 	guiCheckBoxSetSelected(getControl(wndMain, 'freezetime'), state)
 	if state then
 		if not g_TimeFreezeTimer then
-			g_TimeFreezeTimer = setTimer(function(h, m, w) setTime(h, m) setWeather(w) end, 5000, 0, h, m, w)
+			g_TimeFreezeTimer = setTimer(function() setTime(freezeTimeHour, freezeTimeMinute) setWeather(freezeTimeWeather) end, 5000, 0)
 			setMinuteDuration(9001)
 		end
 	else
@@ -1904,6 +1910,7 @@ function applyWeather(leaf)
 	end
 	setWeather(leaf.id)
 	closeWindow(wndWeather)
+	freezeTimeWeather = leaf.id
 end
 
 wndWeather = {


### PR DESCRIPTION
Fix warning when time is set to freeze in fr_client.lua

![grafik](https://user-images.githubusercontent.com/21971680/87658051-f4215d00-c75b-11ea-923e-feca0df455bf.png)
