### PR TITLE
editor: Fix creation of colshapes as children in custom EDFs

### DIFF
--- a/[editor]/edf/edf.lua
+++ b/[editor]/edf/edf.lua
@@ -97,7 +97,7 @@ local edfCreateBasic = {
 			return createColTube(cdata.position[1], cdata.position[2], cdata.position[3], cdata.radius, cdata.height)
 		elseif cdata.type == "rectangle" or cdata.type == "colrectangle" then
 			return createColRectangle(cdata.position[1], cdata.position[2], cdata.position[3], cdata.width, cdata.depth)
-		elseif cdata.type == "cube" or cdata.type == "cuboid" or cdata.type == "colcube" then
+		elseif cdata.type == "cube" or cdata.type == "cuboid" or cdata.type == "colcube" or cdata.type == "colcuboid" then
 			return createColCuboid(cdata.position[1], cdata.position[2], cdata.position[3], cdata.width, cdata.depth, cdata.height)
 		end
 	end,

--- a/[editor]/edf/edf.lua
+++ b/[editor]/edf/edf.lua
@@ -91,14 +91,14 @@ local edfCreateBasic = {
 		return createRadarArea(cdata.posX, cdata.posY, cdata.sizeX, cdata.sizeY, cdata.colorR, cdata.colorG, cdata.colorB, cdata.colorA)
 	end,
 	colshape = function(cdata)
-		if cdata.type == "sphere" then
+		if cdata.type == "sphere" or cdata.type == "colsphere" then
 			return createColSphere(cdata.position[1], cdata.position[2], cdata.position[3], cdata.radius)
-		elseif cdata.type == "tube" then
+		elseif cdata.type == "tube" or cdata.type == "coltube" then
 			return createColTube(cdata.position[1], cdata.position[2], cdata.position[3], cdata.radius, cdata.height)
-		elseif cdata.type == "rectangle" then
+		elseif cdata.type == "rectangle" or cdata.type == "colrectangle" then
 			return createColRectangle(cdata.position[1], cdata.position[2], cdata.position[3], cdata.width, cdata.depth)
-		elseif cdata.type == "cube" or cdata.type == "cuboid" then
-			return createColCube(cdata.position[1], cdata.position[2], cdata.position[3], cdata.width, cdata.depth, cdata.height)
+		elseif cdata.type == "cube" or cdata.type == "cuboid" or cdata.type == "colcube" then
+			return createColCuboid(cdata.position[1], cdata.position[2], cdata.position[3], cdata.width, cdata.depth, cdata.height)
 		end
 	end,
 	ped = function(cdata)


### PR DESCRIPTION
I've noticed that collision shapes are not created properly by editor resource and found the reason.

According to [mtawiki/Resource:Editor/EDF](https://wiki.multitheftauto.com/wiki/Resource:Editor/EDF) and file [editor/edf/datatypes.lua](https://github.com/multitheftauto/mtasa-resources/blob/master/%5Beditor%5D/edf/datatypes.lua#L169) valid types of collision shapes are:
```
One of: "colcircle", "colcube", "colrectangle", "colsphere", "coltube"
```

But in [[editor]/edf/edf.lua](https://github.com/multitheftauto/mtasa-resources/blob/master/%5Beditor%5D/edf/edf.lua#L93) there are checks for different strings - without the "col" in the beginning.

Also I've noticed that instead of ```createColCuboid``` a deprecated function ```createColCube``` is used.

Proposed PR fixes these and colshapes are created.