### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.lua]
+indent_style = space
+indent_size = 4
+end_of_line = crlf


### PR DESCRIPTION
When merged, this will add an [.editorconfig](https://editorconfig.org/) file to the repo to help enforce a consistent coding style. The following rules are set:

- Add final newline and trim trim trailing whitespace from all files
- Use 4 tabs instead of spaces and crlf line endings in .lua files