### PR TITLE
edf: fix min_mta_version warning

### DIFF
--- a/[editor]/edf/meta.xml
+++ b/[editor]/edf/meta.xml
@@ -1,7 +1,7 @@
 <meta>
 	<info author="jbeta" description="Element Definition Format" edf:definition="edf.edf" />
 
-	<min_mta_version client="1.3.5" server="1.3.5" />
+	<min_mta_version client="1.5.7-9.19626" server="1.3.5" />
 
 	<script src="sharedutil.lua" type="shared" />
 	<script src="interface.lua" />


### PR DESCRIPTION
This will fix the following warning:
`WARNING: edf <min_mta_version> section in the meta.xml is incorrect or missing (expected at least client 1.5.7-9.19626 because of 'setPedArmor')`