### PR TITLE
editor: Change `usedLODModels` structure

### DIFF
--- a/[editor]/editor_main/client/mapEditorScriptingExtension_c.lua
+++ b/[editor]/editor_main/client/mapEditorScriptingExtension_c.lua
@@ -8,7 +8,7 @@ end
 addEventHandler("onClientResourceStart", resourceRoot, requestLODsClient)
 
 function setLODsClient(lodTbl)
-	for i, model in ipairs(lodTbl) do
+	for model in pairs(lodTbl) do
 		engineSetModelLODDistance(model, 300)
 	end
 end

--- a/[editor]/editor_main/server/mapEditorScriptingExtension_s.lua
+++ b/[editor]/editor_main/server/mapEditorScriptingExtension_s.lua
@@ -33,7 +33,7 @@ function onResourceStartOrStop ( )
 				setElementDimension(lodObj, getElementDimension(object) )
 				setElementParent(lodObj, object)
 				setLowLODElement(object, lodObj)
-				table.insert(usedLODModels, lodModel)
+				usedLODModels[lodModel] = true
 			end
 		end
 	end


### PR DESCRIPTION
This pull request changes the table structure that transfers the lod models to the client to apply `engineSetModelLODDistance`, which can make loading much faster for resources with very large maps and with many LODS of the same ID.

Currently if the resource has the `useLODs` setting enabled in `meta.xml`, it loop all objects checking if that object has a valid LOD model (using a pre-written table inside the script), and if it does, it will add that model LOD within a table with `table.insert`.

The problem is: if the map file is very large and has many repeated objects with the same lod model, this value will be added several times within the table, and this can make the table very large, when in fact this lod model would only need to be stored once.