### PR TITLE
editor: replaced WARNING with INFO

### DIFF
--- a/[editor]/editor_main/server/freeroam.lua
+++ b/[editor]/editor_main/server/freeroam.lua
@@ -7,7 +7,8 @@ addEventHandler("onResourceStart",getResourceRootElement(getThisResource()),
 
 		if getResourceState(freeroam) == "running" then
 			outputChatBox ( "INFO: 'FREEROAM' resource is currently running.  The resource has been shut off as a precaution!", getRootElement(), 255, 255, 0 )
-			outputDebugString (  "INFO: 'FREEROAM' resource is currently running.  The resource has been shut off as a precaution!" )
+			outputDebugString (  "'FREEROAM' resource is currently running.  The resource has been shut off as a precaution!" )
+
 			stopResource(freeroam)
 		end
 	end

--- a/[editor]/editor_main/server/freeroam.lua
+++ b/[editor]/editor_main/server/freeroam.lua
@@ -7,8 +7,7 @@ addEventHandler("onResourceStart",getResourceRootElement(getThisResource()),
 
 		if getResourceState(freeroam) == "running" then
 			outputChatBox ( "INFO: 'FREEROAM' resource is currently running.  The resource has been shut off as a precaution!", getRootElement(), 255, 255, 0 )
-			outputDebugString (  "'FREEROAM' resource is currently running.  The resource has been shut off as a precaution!" )
-
+			outputDebugString (  "'FREEROAM' resource is currently running.  The resource has been shut off as a precaution!",4,255,255,0 )
 			stopResource(freeroam)
 		end
 	end

--- a/[editor]/editor_main/server/freeroam.lua
+++ b/[editor]/editor_main/server/freeroam.lua
@@ -6,8 +6,8 @@ addEventHandler("onResourceStart",getResourceRootElement(getThisResource()),
 		end
 
 		if getResourceState(freeroam) == "running" then
-			outputChatBox ( "WARNING: 'FREEROAM' resource is currently running.  The resource has been shut off as a precaution!", getRootElement(), 255, 0, 0 )
-			outputDebugString (  "WARNING: 'FREEROAM' resource is currently running.  The resource has been shut off as a precaution!" )
+			outputChatBox ( "INFO: 'FREEROAM' resource is currently running.  The resource has been shut off as a precaution!", getRootElement(), 255, 255, 0 )
+			outputDebugString (  "INFO: 'FREEROAM' resource is currently running.  The resource has been shut off as a precaution!" )
 			stopResource(freeroam)
 		end
 	end


### PR DESCRIPTION
hi, I always thought WARNING was a bit of an error message with red text and all so I replaced WARNING: string with INFO: and changed the text to appear as yellow instead of red.

this message appears when you start Editor resource while freeroam is running.