### PR TITLE
Race : Problem to restore rotation of vehicles - restorePlayer function - base.lua

### DIFF
--- a/[gamemodes]/[race]/race/modes/base.lua
+++ b/[gamemodes]/[race]/race/modes/base.lua
@@ -417,7 +417,7 @@ function restorePlayer(id, player, bNoFade, bDontFix)
 	if not RaceMode.checkpointsExist() or checkpoint==1 then
 		local spawnpoint = self:pickFreeSpawnpoint(player)
 		bkp.position = spawnpoint.position
-		bkp.rotation = {0, 0, spawnpoint.rotation[3]}
+		bkp.rotation = spawnpoint.rotation
 		bkp.geardown = true                 -- Fix landing gear state
 		bkp.vehicle = spawnpoint.vehicle    -- Fix spawn'n'blow
 		--setVehicleID(RaceMode.getPlayerVehicle(player), spawnpoint.vehicle)

--- a/[gamemodes]/[race]/race/modes/base.lua
+++ b/[gamemodes]/[race]/race/modes/base.lua
@@ -417,7 +417,7 @@ function restorePlayer(id, player, bNoFade, bDontFix)
 	if not RaceMode.checkpointsExist() or checkpoint==1 then
 		local spawnpoint = self:pickFreeSpawnpoint(player)
 		bkp.position = spawnpoint.position
-		bkp.rotation = {0, 0, spawnpoint.rotation}
+		bkp.rotation = {0, 0, spawnpoint.rotation[3]}
 		bkp.geardown = true                 -- Fix landing gear state
 		bkp.vehicle = spawnpoint.vehicle    -- Fix spawn'n'blow
 		--setVehicleID(RaceMode.getPlayerVehicle(player), spawnpoint.vehicle)


### PR DESCRIPTION
Hello,

While playing destruction derby maps with respawn of vehicles, rotation of vehicles had a little problem while respawning :

`WARNING: [gamemodes]/[race]/race/modes/base.lua:438: Bad argument @ 'setVehicleRotation' [Expected number at argument 4, got table]`

Here I suggest the way I solved it.

Have a nice evening.