### PR TITLE
stop trying to restart non-running resources

### DIFF
--- a/[admin]/admin/server/admin_server.lua
+++ b/[admin]/admin/server/admin_server.lua
@@ -1261,7 +1261,10 @@ addEventHandler ( "aResource", _root, function ( name, action )
 	if ( hasObjectPermissionTo ( source, "command."..action ) ) then
 		local text = ""
 		if ( action == "start" ) then if ( startResource ( getResourceFromName ( name ), true ) ) then text = "started" end
-		elseif ( action == "restart" ) then if ( restartResource ( getResourceFromName ( name ) ) ) then text = "restarted" end
+		elseif ( action == "restart" ) then
+				if ( getResourceState ( getResourceFromName ( name ) ) == "running" ) then
+					if ( restartResource ( getResourceFromName ( name ) ) ) then text = "restarted" end
+				end
 		elseif ( action == "stop" ) then if ( stopResource ( getResourceFromName ( name ) ) ) then text = "stopped" end
 		elseif ( action == "delete" ) then if ( deleteResource ( getResourceFromName ( name ) ) ) then text = "deleted" end
 		elseif ( action == "stopall" ) then if ( stopAllResources ( ) ) then text = "All Stopped" end

--- a/[admin]/ipb/README.md
+++ b/[admin]/ipb/README.md
@@ -1,0 +1,43 @@
+# Ingame Performance Browser
+
+This resource allows you to see various performance information while ingame. 
+
+## Usage 
+
+Type `/ipb` to see performance stats. There are two targets, listed below.
+
+**Client** with 5 categories:
+
+- Lua timing
+- Lua time recordings
+- Lua memory
+- Lib memory 
+- Packet usage 
+
+**Server** with 13 categories:
+
+- Server info
+- Lua timing
+- Lua time recordings
+- Lua memory
+- Packet usage
+- Sqlite timing 
+- Bandwidth reduction
+- Bandwidth usage 
+- Server timing
+- Function stats
+- Debug info
+- Debug table
+- Lib memory
+
+## Settings 
+
+You can find 4 options in meta.xml, listed below.
+
+**SaveHighCPUResources** - Save to RAM (every 5 seconds) CPU usage of resources that are using over specified % to debug when web/ingame PB isn't accessible
+
+**SaveHighCPUResourcesAmount** - The amount of CPU a resource must use before being logged as a high CPU user. Default: 10
+
+**NotifyIPBUsersOfHighUsage** - Requires SaveHighCPUResources to be enabled. Will notify any IPB users if a resources goes over the specified value of CPU %. Default is 50. Set to 1000 to disable.
+
+**AccessRightName** - The name of the access right that a player needs in order to be able to use IPB. Default: general.http


### PR DESCRIPTION
trying to restart non-running resource results in a warning in the debug console