### PR TITLE
reload: few changes

### DIFF
--- a/[gameplay]/reload/reload.lua
+++ b/[gameplay]/reload/reload.lua
@@ -1,5 +1,7 @@
-function reloadWeapon()
-	reloadPedWeapon(client)
+local function reloadWeapon()
+	if client then
+		reloadPedWeapon(client)
+	end
 end
 addEvent("relWep", true)
-addEventHandler("relWep", resourceRoot, reloadWeapon)
+addEventHandler("relWep", root, reloadWeapon)

--- a/[gameplay]/reload/reload.lua
+++ b/[gameplay]/reload/reload.lua
@@ -1,7 +1,5 @@
 local function reloadWeapon()
-	if client then
-		reloadPedWeapon(client)
-	end
+	reloadPedWeapon(client)
 end
 addEvent("relWep", true)
 addEventHandler("relWep", root, reloadWeapon)

--- a/[gameplay]/reload/reload_c.lua
+++ b/[gameplay]/reload/reload_c.lua
@@ -13,17 +13,20 @@ local blockedTasks = {
     ["TASK_SIMPLE_CAR_OPEN_DOOR_FROM_OUTSIDE"] = true,
 }
 
-local function reloadWeapon()
+local function reloadTimer()
     if blockedTasks[getPedSimplestTask(localPlayer)] then
         return
     end
-    triggerServerEvent("relWep", resourceRoot)
+
+    triggerServerEvent("relWep", localPlayer)
 end
 
 -- The jump task is not instantly detectable and bindKey works quicker than getControlState
 -- If you try to reload and jump at the same time, you will be able to instant reload.
 -- We work around this by adding an unnoticable delay to foil this exploit.
-addCommandHandler("Reload weapon", function()
-    setTimer(reloadWeapon, 50, 1)
-end)
+
+local function reloadWeapon()
+	setTimer(reloadTimer, 50, 1)
+end
+addCommandHandler("Reload weapon", reloadWeapon)
 bindKey("r", "down", "Reload weapon")


### PR DESCRIPTION
Client:
- Replaced anonymous function with non anonymous, it's called reloadWeapon now.
- Renamed function **reloadWeapon** -> **reloadTimer** since it's called via timer.
- Due of that reloadWeapon it's now used as command handler/bind.
- triggerServerEvent uses localPlayer instead of resourceRoot.

Server:
- Localized event function.
- Added if check for client, according [to this wiki article.](https://wiki.multitheftauto.com/wiki/Script_security)
- Event's bound element changed to root, so it could also accept player as a source element.