### PR TITLE
IPB: Fix filter editbox

### DIFF
--- a/[admin]/ipb/client/gui.lua
+++ b/[admin]/ipb/client/gui.lua
@@ -276,7 +276,7 @@ function GUI:updateStatistics(mode)
         return
     end
 
-    self:fill(mode, getPerformanceStats(self.categoryItem, self.options:getText(), self.options:getText()))
+    self:fill(mode, getPerformanceStats(self.categoryItem, self.options:getText(), self.filter:getText()))
 end
 
 function GUI:fill(mode, columns, rows)


### PR DESCRIPTION
This PR fixes a logic error, which caused the text in the `options` edit box to be used as filter param, and the `filter` edit box simply doesn't work.