### PR TITLE
freeroam: fix /addclothes error

### DIFF
--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -502,15 +502,11 @@ wndClothes = {
 
 function addClothesCommand(cmd, type, model, texture)
 	type = type and tonumber(type)
-
-	if string.len(type) > 30 or string.len(model) > 30 or string.len(texture) > 30 then
-		errMsg("Invalid clothes input!")
+	if (not type or string.len(type) > 30) or (not model or string.len(model) > 30) or (not texture or string.len(texture) > 30) then
+		errMsg("Invalid clothes input! Usage: /"..cmd.." [type] [model] [texture]")
 		return
 	end
-
-	if type and model and texture then
-		server.addPedClothes(localPlayer, texture, model, type)
-	end
+	server.addPedClothes(localPlayer, texture, model, type)
 end
 addCommandHandler('addclothes', addClothesCommand)
 addCommandHandler('ac', addClothesCommand)


### PR DESCRIPTION
When merged, this PR will fix the following error:

![image](https://user-images.githubusercontent.com/30420446/113515478-6ef60680-957d-11eb-80e7-140a77d2f4d9.png)
to reproduce it just use the command `addclothes` without arguments.