### PR TITLE
freeroam: fix warning when using /color with negative number

### DIFF
--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -1678,7 +1678,8 @@ function setColorCommand(cmd, ...)
 	end
 
 	for i = 1, 12 do
-		colors[i] = args[i] and tonumber(args[i]) or colors[i]
+		local color = tonumber(args[i]) or -1
+		colors[i] = color >= 0 and color or colors[i]
 	end
 	server.setVehicleColor(vehicle, unpack(colors))
 end


### PR DESCRIPTION
When merged, this PR will fix the following warning:
![image](https://user-images.githubusercontent.com/30420446/113516172-78816d80-9581-11eb-975e-c9f626a1599a.png)
