### PR TITLE
votemanager: fix warning after cancelling a vote and choosing some option

### DIFF
--- a/[managers]/votemanager/votemanager_client.lua
+++ b/[managers]/votemanager/votemanager_client.lua
@@ -320,7 +320,7 @@ function sendVote(voteID)
 
 	--if the player hasnt voted already (or if vote change is allowed anyway), update the vote text
 	if not hasAlreadyVoted or isChangeAllowed then
-		if hasAlreadyVoted then
+		if hasAlreadyVoted and hasAlreadyVoted ~= -1 then
 			guiSetFont(optionLabels[hasAlreadyVoted], layout.option.font)
 			guiSetAlpha(optionLabels[hasAlreadyVoted], layout.option.alpha)
 			guiLabelSetColor(optionLabels[hasAlreadyVoted], layout.option.r, layout.option.g, layout.option.b)


### PR DESCRIPTION
This PR fixes warning (in the screenshot below) after cancelling a vote and choosing some option.
![image](https://user-images.githubusercontent.com/12110157/114298258-24fdab00-9abe-11eb-80d7-d17671576028.png)
To reproduce it, just vote for any option, then cancel your vote _(press Backspace)_ 2 times.