### PR TITLE
speedometer: Check vehicle occupied by localPlayer

### DIFF
--- a/[gameplay]/speedometer/client.lua
+++ b/[gameplay]/speedometer/client.lua
@@ -62,6 +62,7 @@ addEventHandler("onClientElementDestroy", root, destroyHandler)
 -- If player vehicle changes in abnormal way (e.g drives into a vehicle pick-up)
 local function onVehicleTypeChange(oldModel, newModel)
     if (getElementType(source) ~= "vehicle") then return end
+    if (getPedOccupiedVehicle(localPlayer) ~= source) then return end
 
     local newType = getVehicleType(newModel)
 

--- a/[gameplay]/speedometer/client.lua
+++ b/[gameplay]/speedometer/client.lua
@@ -61,7 +61,6 @@ addEventHandler("onClientElementDestroy", root, destroyHandler)
 
 -- If player vehicle changes in abnormal way (e.g drives into a vehicle pick-up)
 local function onVehicleTypeChange(oldModel, newModel)
-    if (getElementType(source) ~= "vehicle") then return end
     if (getPedOccupiedVehicle(localPlayer) ~= source) then return end
 
     local newType = getVehicleType(newModel)


### PR DESCRIPTION
When onClientElementModelChange is triggered it doesn't check that localPlayer is an occupant of source. So when you're inside a plane it sometimes showsSpeedo randomly (when the event is triggered elsewhere)