### PR TITLE
Bump admin version number for upcoming release

### DIFF
--- a/[admin]/admin/client/admin_client.lua
+++ b/[admin]/admin/client/admin_client.lua
@@ -10,7 +10,7 @@
 
 _DEBUG = false
 
-_version = '1.5.5'
+_version = '1.5.9'
 _root = getRootElement()
 _flags = {}
 _widgets = {}

--- a/[admin]/admin/meta.xml
+++ b/[admin]/admin/meta.xml
@@ -1,5 +1,5 @@
 <meta>
-  <info author="lil_Toady" type="misc" version="1.5.5" />
+  <info author="lil_Toady" type="misc" version="1.5.9" />
   <min_mta_version server="1.3.3" client="1.5.6-9.16361"/>
   <!--
     Admin System Meta File.


### PR DESCRIPTION
This PR bumps `admin`s version number for the next release. As recommended by @iDannz1 in Discord, this will help advertise the fact that admin has had a number of improvements since the last release cycle and hopefully encourage admins to update.