### PR TITLE
killmessages: fix dup rows

### DIFF
--- a/[gameplay]/killmessages/scripts/client/c.killmessages.lua
+++ b/[gameplay]/killmessages/scripts/client/c.killmessages.lua
@@ -134,10 +134,12 @@ end)
 
 addEventHandler('onClientPlayerWasted', localPlayer, function()
     if (not possibleKiller) then
-        -- If there is no possible killer and the current vehicle is exploded
         local myVehicle = getPedOccupiedVehicle(localPlayer)
-        myVehicle = myVehicle and isVehicleBlown(myVehicle)
-        triggerServerEvent('outputKillFromClient', localPlayer, localPlayer, myVehicle)
+
+        if myVehicle and isVehicleBlown(myVehicle) then
+            triggerServerEvent('outputKillFromClient', localPlayer, localPlayer, myVehicle)
+        end
+
         return
     end
 


### PR DESCRIPTION
This PR fixes the bug that duplicates the displayed lines but also ends up disabling ``freeroam`` suicide detection, so we need another method to detect it. ~~Anyway, I'm going to open an issue requesting this functionality back.~~