### PR TITLE
admin/admin2: Fix bans warning

### DIFF
--- a/[admin]/admin/client/gui/admin_ban.lua
+++ b/[admin]/admin/client/gui/admin_ban.lua
@@ -92,8 +92,6 @@ function aClientBanClick ( button )
 	if ( button == "left" ) then
 		if ( source == aBanClose ) then
 			aBanDetailsClose ( false )
-		elseif ( source == aBanUnban ) then
-			triggerEvent ( "onClientGUIClick", aTab4.BansUnban, "left" )
 		elseif ( source == aBanCopy ) then
 			setClipboard( clipContent[2] )
 			outputChatBox( "Successfully copied the " .. clipContent[1] .. " into clipboard.", 255, 100, 70 )

--- a/[admin]/admin2/client/widgets/admin_ban.lua
+++ b/[admin]/admin2/client/widgets/admin_ban.lua
@@ -91,8 +91,6 @@ function aClientBanClick(button)
     if (button == "left") then
         if (source == aBanClose) then
             aBanDetailsClose(false)
-        elseif (source == aBanUnban) then
-            triggerEvent("onClientGUIClick", aTab4.BansUnban, "left")
         end
     end
 end


### PR DESCRIPTION
This PR removes a warning that appears when clicking on the following label:
![image](https://user-images.githubusercontent.com/38073795/130477765-86bd03c8-8e3b-4848-a0c1-af1968855243.png)
![image](https://user-images.githubusercontent.com/38073795/130477811-d5f673d0-9bfa-4610-b659-1ee0065eb6b4.png)