### PR TITLE
editor: Make interior world models removable

### DIFF
--- a/[editor]/edf/edf.lua
+++ b/[editor]/edf/edf.lua
@@ -625,6 +625,7 @@ function edfCreateElement(elementType, creatorClient, fromResource, parametersTa
 				edfSetElementRotation(newElement, dataValue[1], dataValue[2], dataValue[3])
 			elseif dataField == "interior" then
 				setElementInterior(newElement, dataValue)
+				setElementData(newElement, dataField, dataValue)
 			elseif dataField == "dimension" then
 				setElementDimension(newElement, dataValue)
 			elseif dataField == "alpha" then

--- a/[editor]/editor_main/client/main.lua
+++ b/[editor]/editor_main/client/main.lua
@@ -1347,6 +1347,9 @@ function handleWorldBuildingMode(keyState)
 					creationParameters.radius = radius
 					creationParameters.position = { g_worldBuildingInfo.x, g_worldBuildingInfo.y, g_worldBuildingInfo.z }
 					creationParameters.interior = g_workingInterior
+					if creationParameters.interior == 0 then
+						creationParameters.interior = -1
+					end
 					triggerServerEvent ( "doCreateElement", localPlayer, "removeWorldObject", "editor_main", creationParameters, false )
 				else
 					creationParameters = {}


### PR DESCRIPTION
Currently you can't remove interior world models in the editor.

In the below snippet from editor_main `interior` is always 0.

```lua
function onWorldObjectCreateOrDestroy ( )
	if ( getElementType ( source ) == "removeWorldObject" ) then
		local model = getElementData ( source, "model" )
		local lodModel = getElementData ( source, "lodModel" )
		local posX = getElementData ( source, "posX" )
		local posY = getElementData ( source, "posY" )
		local posZ = getElementData ( source, "posZ" )
		local interior = getElementData ( source, "interior" )
		local radius = getElementData ( source, "radius" )
		if ( eventName == "onElementCreate" ) then
			removeWorldModel ( model, radius, posX, posY, posZ, interior )
			removeWorldModel ( lodModel, radius, posX, posY, posZ, interior )
		else
			restoreWorldModel ( model, radius, posX, posY, posZ, interior )
			restoreWorldModel ( lodModel, radius, posX, posY, posZ, interior )
		end
	end
end
```

This PR saves the interior in element data like model, position, radius.

Secondly, certain duplicated models in interior 13 also appear in the outside world, like the train station in SF, so these couldnt be removed. Now -1 is used instead of 0 to apply the removal across all interiors.