### PR TITLE
freeroam: replace setElementHealth to killPed

### DIFF
--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -2130,7 +2130,9 @@ addEventHandler("onClientElementDestroy", root, onExitVehicle)
 
 function killLocalPlayer()
 	if g_settings["kill"] then
-		setElementHealth(localPlayer,0)
+		if (not isPedDead(localPlayer)) then
+			triggerServerEvent("onFreeroamSuicide", localPlayer)
+		end
 	else
 		errMsg("Killing yourself is disallowed!")
 	end

--- a/[gameplay]/freeroam/fr_server.lua
+++ b/[gameplay]/freeroam/fr_server.lua
@@ -609,7 +609,5 @@ addEvent('onFreeroamSuicide', true)
 addEventHandler('onFreeroamSuicide', root, function ()
 	if isElement(client) and (not isPedDead(client)) then
 		killPed(client, client)
-	else
-		print('flood', getTickCount())
 	end
 end)

--- a/[gameplay]/freeroam/fr_server.lua
+++ b/[gameplay]/freeroam/fr_server.lua
@@ -604,3 +604,12 @@ function getPlayerName(player)
 end
 
 addEvent("onFreeroamLocalSettingChange",true)
+
+addEvent('onFreeroamSuicide', true)
+addEventHandler('onFreeroamSuicide', root, function ()
+	if isElement(client) and (not isPedDead(client)) then
+		killPed(client, client)
+	else
+		print('flood', getTickCount())
+	end
+end)


### PR DESCRIPTION
This PR replaces `setElementHealth(localPlayer, 0)` to `killPed` in the suicide function.

The reason it is necessary is that currently the `onPlayerWasted` event is receiving incorrect parameters after `setElementHealth`, and it has broken the detection on `killmessages` because the `weapon` parameter is being sent as id 63, which actually should only be sent if the player dies in an explosion.

So, after the `killmessages` rewrite (2e356cb) it was adapted to detect kills from vehicle explosions, and we ended up having to [ignore the explosion deaths within the onPlayerWasted event](https://github.com/multitheftauto/mtasa-resources/blob/master/%5Bgameplay%5D/killmessages/scripts/server/s.killmessages.lua#L52) because they are being computed client-side, and as the `weapon` parameter is being confused, this ended up also disabling suicide messages.