### PR TITLE
editor_main: improve gamemodestopper

### DIFF
--- a/[editor]/editor_main/gamemodestopper.lua
+++ b/[editor]/editor_main/gamemodestopper.lua
@@ -1,5 +1,5 @@
 function isResourceRunning(res)
-	return getResourceState(res)=="running"
+	return getResourceState(res) == "running"
 end
 
 function isGamemode(res)
@@ -10,17 +10,28 @@ function isMap(res)
 	return exports.mapmanager:isMap(res)
 end
 
-addEventHandler("onResourceStart", getResourceRootElement(),
-	function()
-		for index,resource in ipairs(getResources()) do
-			if isResourceRunning(resource) and (isGamemode(resource) or isMap(resource)) then
-				if hasObjectPermissionTo(getThisResource(), "function.stopResource") then
-					stopResource(resource)
-				else
-					outputDebugString("Editor: Unable to stop running gamemodes (no access to function.stopResource)")
-					return
-				end
+function onResourceStart(startedResource)
+	local stopPermission = hasObjectPermissionTo(startedResource, "function.stopResource")
+
+	if not stopPermission then
+		outputDebugString("Editor: Unable to stop running gamemodes (no access to function.stopResource)")
+
+		return false
+	end
+
+	local resourcesTable = getResources()
+
+	for resourceID = 1, #resourcesTable do
+		local resourceElement = resourcesTable[resourceID]
+		local resourceRunning = isResourceRunning(resourceElement)
+
+		if resourceRunning then
+			local gamemodeOrMap = isGamemode(resourceElement) or isMap(resourceElement)
+
+			if gamemodeOrMap then
+				stopResource(resourceElement)
 			end
 		end
 	end
-)
+end
+addEventHandler("onResourceStart", resourceRoot, onResourceStart)

--- a/[editor]/editor_main/gamemodestopper.lua
+++ b/[editor]/editor_main/gamemodestopper.lua
@@ -11,9 +11,7 @@ function isMap(res)
 end
 
 function onResourceStart(startedResource)
-	local stopPermission = hasObjectPermissionTo(startedResource, "function.stopResource")
-
-	if not stopPermission then
+	if not hasObjectPermissionTo(startedResource, "function.stopResource") then
 		outputDebugString("Editor: Unable to stop running gamemodes (no access to function.stopResource)")
 
 		return false
@@ -23,9 +21,8 @@ function onResourceStart(startedResource)
 
 	for resourceID = 1, #resourcesTable do
 		local resourceElement = resourcesTable[resourceID]
-		local resourceRunning = isResourceRunning(resourceElement)
 
-		if resourceRunning then
+		if isResourceRunning(resourceElement) then
 			local gamemodeOrMap = isGamemode(resourceElement) or isMap(resourceElement)
 
 			if gamemodeOrMap then


### PR DESCRIPTION
- Replaced bound element to predefined resourceRoot
- Used startedResource from parameters instead of method call getThisResource()
- Loop isn't called anymore when resource can't stop other resources (missing perms)
- Also it's no longer in it's scope (perm check)
- Replaced ipairs with better equivalent
- Improved readability