### PR TITLE
enhancement: joinquit settings support + code refactor

### DIFF
--- a/[gameplay]/joinquit/joinquit.lua
+++ b/[gameplay]/joinquit/joinquit.lua
@@ -1,59 +1,65 @@
-local showColorCodes = true; 		-- Shows player's names colorcoded if set to true, and if set to false it doesn't
-local defaultHexCode = "#4E5768"; 	-- Hex code for what color to output messages in (only used if showColorCodes is true)
+local resourceName = (Resource.getThis()).name
+local settingPrefix = ("*%s."):format(resourceName)
 
+local showColorCodes = get("showColorCodes") == "true" 	-- Shows player"s names colorcoded if set to true, and if set to false it doesn"t
+local defaultColor = get("defaultColor")				-- Hex code for what color to output messages in (only used if showColorCodes is true)
+local fallbackHexCode = "#4E5768"						-- Fallback hex code for incorrectly input settings values
+
+function reloadSettings(settingName)
+	-- Setting change affects this resource
+	if (settingName:find(settingPrefix, 1, true)) then
+		showColorCodes = get("showColorCodes") == "true"
+		defaultColor = get("defaultColor")
+	end
+end
+addEventHandler("onSettingChange", root, reloadSettings)
 
 -- This function converts RGB colors to colorcodes like #ffffff
-function RGBToHex(red, green, blue, alpha)
-
+function RGBToHex(red, green, blue)
 	-- Make sure RGB values passed to this function are correct
-	if( ( red < 0 or red > 255 or green < 0 or green > 255 or blue < 0 or blue > 255 ) or ( alpha and ( alpha < 0 or alpha > 255 ) ) ) then
+	if (not red or not green or not blue or (red < 0 or red > 255 or green < 0 or green > 255 or blue < 0 or blue > 255)) then
 		return nil
 	end
 
-	-- Alpha check
-	if alpha then
-		return string.format("#%.2X%.2X%.2X%.2X", red, green, blue, alpha)
-	else
-		return string.format("#%.2X%.2X%.2X", red, green, blue)
-	end
-
+	return string.format("#%.2X%.2X%.2X", red, green, blue)
 end
 
-
-addEventHandler('onClientPlayerJoin', root,
-	function()
-
-		if showColorCodes then
-			outputChatBox(defaultHexCode .. '* ' .. RGBToHex(getPlayerNametagColor(source)) .. getPlayerName(source) .. defaultHexCode .. ' has joined the game', 255, 100, 100, true)
-		else
-			outputChatBox('* ' .. getPlayerName(source) .. ' has joined the game', 255, 100, 100)
-		end
-
+function getDefaultColor()
+	local hexColor = RGBToHex(defaultColor[1], defaultColor[2], defaultColor[3])
+	if (not hexColor) then
+		return fallbackHexCode
 	end
-)
 
+	return hexColor
+end
 
-addEventHandler('onClientPlayerChangeNick', root,
-	function(oldNick, newNick)
+function getHexFriendlyNick(player, nick)
+	return RGBToHex(player:getNametagColor())..nick
+end
 
-		if showColorCodes then
-			outputChatBox(defaultHexCode .. '* ' .. RGBToHex(getPlayerNametagColor(source)) .. oldNick .. defaultHexCode .. ' is now known as ' .. RGBToHex(getPlayerNametagColor(source)) .. newNick, 255, 100, 100, true)
-		else
-			outputChatBox('* ' .. oldNick .. ' is now known as ' .. newNick, 255, 100, 100)
-		end
-
+function joinMessage()
+	if (showColorCodes) then
+		outputChatBox(getDefaultColor().."* "..getHexFriendlyNick(source, source.name)..getDefaultColor().." has joined the game", root, 255, 100, 100, true)
+	else
+		outputChatBox("* "..source.name.." has joined the game", root, 255, 100, 100)
 	end
-)
+end
+addEventHandler("onPlayerJoin", root, joinMessage)
 
-
-addEventHandler('onClientPlayerQuit', root,
-	function(reason)
-
-		if showColorCodes then
-			outputChatBox(defaultHexCode .. '* ' .. RGBToHex(getPlayerNametagColor(source)) .. getPlayerName(source) .. defaultHexCode .. ' has left the game [' .. reason .. ']', 255, 100, 100, true)
-		else
-			outputChatBox('* ' .. getPlayerName(source) .. ' has left the game [' .. reason .. ']', 255, 100, 100)
-		end
-
+function nickChangeMessage(oldNick, newNick)
+	if (showColorCodes) then
+		outputChatBox(getDefaultColor().."* "..getHexFriendlyNick(source, oldNick)..getDefaultColor().." is now known as "..getHexFriendlyNick(source, newNick), root, 255, 100, 100, true)
+	else
+		outputChatBox("* "..oldNick.." is now known as "..newNick, root, 255, 100, 100)
 	end
-)
+end
+addEventHandler("onPlayerChangeNick", root, nickChangeMessage)
+
+function leftMessage(reason)
+	if (showColorCodes) then
+		outputChatBox(getDefaultColor().."* "..getHexFriendlyNick(source, source.name)..getDefaultColor().." has left the game ["..reason.."]", root, 255, 100, 100, true)
+	else
+		outputChatBox("* "..source.name.." has left the game ["..reason.."]", root, 255, 100, 100)
+	end
+end
+addEventHandler("onPlayerQuit", root, leftMessage)

--- a/[gameplay]/joinquit/joinquit.lua
+++ b/[gameplay]/joinquit/joinquit.lua
@@ -1,5 +1,5 @@
-local resourceName = (Resource.getThis()).name
-local settingPrefix = ("*%s."):format(resourceName)
+local resourceName = getResourceName(getThisResource())
+local settingPrefix = string.format("*%s.", resourceName)
 
 local showColorCodes = get("showColorCodes") == "true" 	-- Shows player"s names colorcoded if set to true, and if set to false it doesn"t
 local defaultColor = get("defaultColor")				-- Hex code for what color to output messages in (only used if showColorCodes is true)
@@ -7,7 +7,7 @@ local fallbackHexCode = "#4E5768"						-- Fallback hex code for incorrectly inpu
 
 function reloadSettings(settingName)
 	-- Setting change affects this resource
-	if (settingName:find(settingPrefix, 1, true)) then
+	if (string.find(settingName, settingPrefix, 1, true)) then
 		showColorCodes = get("showColorCodes") == "true"
 		defaultColor = get("defaultColor")
 	end
@@ -34,14 +34,14 @@ function getDefaultColor()
 end
 
 function getHexFriendlyNick(player, nick)
-	return RGBToHex(player:getNametagColor())..nick
+	return RGBToHex(getPlayerNametagColor(player))..nick
 end
 
 function joinMessage()
 	if (showColorCodes) then
-		outputChatBox(getDefaultColor().."* "..getHexFriendlyNick(source, source.name)..getDefaultColor().." has joined the game", root, 255, 100, 100, true)
+		outputChatBox(getDefaultColor().."* "..getHexFriendlyNick(source, getPlayerName(source))..getDefaultColor().." has joined the game", root, 255, 100, 100, true)
 	else
-		outputChatBox("* "..source.name.." has joined the game", root, 255, 100, 100)
+		outputChatBox("* "..getPlayerName(source).." has joined the game", root, 255, 100, 100)
 	end
 end
 addEventHandler("onPlayerJoin", root, joinMessage)
@@ -57,9 +57,9 @@ addEventHandler("onPlayerChangeNick", root, nickChangeMessage)
 
 function leftMessage(reason)
 	if (showColorCodes) then
-		outputChatBox(getDefaultColor().."* "..getHexFriendlyNick(source, source.name)..getDefaultColor().." has left the game ["..reason.."]", root, 255, 100, 100, true)
+		outputChatBox(getDefaultColor().."* "..getHexFriendlyNick(source, getPlayerName(source))..getDefaultColor().." has left the game ["..reason.."]", root, 255, 100, 100, true)
 	else
-		outputChatBox("* "..source.name.." has left the game ["..reason.."]", root, 255, 100, 100)
+		outputChatBox("* "..getPlayerName(source).." has left the game ["..reason.."]", root, 255, 100, 100)
 	end
 end
 addEventHandler("onPlayerQuit", root, leftMessage)

--- a/[gameplay]/joinquit/meta.xml
+++ b/[gameplay]/joinquit/meta.xml
@@ -1,3 +1,19 @@
 <meta>
-	<script src="joinquit.lua" type="client" />
+	<info name="joinquit" author="Noki" description="Messages in the chat when players join or quit" type="script" />  
+	<script src="joinquit.lua" type="server" />
+	<settings>
+		<setting name="*showColorCodes"
+			friendlyname="Show Color Codes"
+			value="true"
+			accept="true,false"
+			desc="Allow hex color codes in nicknames to be shown in the chat"
+		/>
+		<setting name="*defaultColor"
+			friendlyname="Default Color"
+			value="[[78, 87, 104]]"
+			accept=""
+			desc="If show color codes is set to true, this controls what color to output messages in"
+		/>
+	</settings>
+	<oop>true</oop>
 </meta>

--- a/[gameplay]/joinquit/meta.xml
+++ b/[gameplay]/joinquit/meta.xml
@@ -15,5 +15,4 @@
 			desc="If show color codes is set to true, this controls what color to output messages in"
 		/>
 	</settings>
-	<oop>true</oop>
 </meta>


### PR DESCRIPTION
This PR introduces some quality of life improvements to the `joinquit` resource, as well as some basic enhancements:
- Moved the script server-side
- Added `*showColorCodes` setting which accepts a boolean value
- Added `*defaultColor` setting which accepts an RGB input, and controls what color to output the message text in
- Removed anonymous functions 
- Removed redundant support for alpha values which weren't present in hex code so I'm not sure why we used them
- Resource listens for settings changes
- Moved a few pieces of functionality into functions, namely `getDefaultColor` (which has a fallback now) and `getHexFriendlyNick` which makes the `outputChatBox` calls read nicer