### PR TITLE
editor_main: Disable OOP in meta.xml for scripting extensions

### DIFF
--- a/[editor]/editor_main/server/dumpxml.lua
+++ b/[editor]/editor_main/server/dumpxml.lua
@@ -81,8 +81,8 @@ function dumpMeta ( xml, extraNodes, resource, filename, test )
 	extraNodes = extraNodes or {}
 
 	--Add OOP support
-	local oopNode = xmlCreateChild(xml, "oop")
-	xmlNodeSetValue(oopNode, "true")
+	--[[local oopNode = xmlCreateChild(xml, "oop")
+	xmlNodeSetValue(oopNode, "true")]]
 
 	--[[ info tag ]]--
 	local infoNode = xmlCreateChild(xml, "info")


### PR DESCRIPTION
Disabling it due of being unnecessary (no single OOP call was being used).