### PR TITLE
Add frameratefixes resource

### DIFF
--- a/[gameplay]/frameratefixes/client.lua
+++ b/[gameplay]/frameratefixes/client.lua
@@ -1,0 +1,13 @@
+-- Fix for "Climbing over certain objects kills you, when you have high FPS"
+-- https://github.com/multitheftauto/mtasa-blue/issues/602
+addEventHandler("onClientPlayerDamage", localPlayer,
+	function(attacker, weapon, bodypart)
+		if not attacker and weapon == 54 and bodypart == 3 then
+			local task = {}
+			task[1], task[2], task[3] = getPedTask(localPlayer, "primary", 3)
+			if task[1] == "TASK_COMPLEX_JUMP" and task[2] == "TASK_COMPLEX_IN_AIR_AND_LAND" and task[3] == "TASK_SIMPLE_CLIMB" then
+				cancelEvent()
+			end
+		end
+	end
+)

--- a/[gameplay]/frameratefixes/meta.xml
+++ b/[gameplay]/frameratefixes/meta.xml
@@ -1,0 +1,4 @@
+<meta>
+	<info name="Framerate Fixes" version="1.0.0" author="lopezloo" type="script" description="Fixes framerate related issues." />
+	<script src="client.lua" type="client" />
+</meta>


### PR DESCRIPTION
This PR adds new default resource with purpose of fixing framerate related issues. Currently it fixes https://github.com/multitheftauto/mtasa-blue/issues/602.