### PR TITLE
Fix "No map selected!" message box when clicking search map editbox

### DIFF
--- a/[admin]/admin/client/gui/admin_maps.lua
+++ b/[admin]/admin/client/gui/admin_maps.lua
@@ -66,7 +66,7 @@ function guiClick(button)
 				guiGridListClear(aTabMap.MapList)
 				triggerServerEvent("getMaps_s", localPlayer, true)
 			end
-			if guiGridListGetSelectedItem ( aTabMap.MapList ) == -1 then
+			if ( source ~= aTabMap.MapListSearch ) and guiGridListGetSelectedItem ( aTabMap.MapList ) == -1 then
 				aMessageBox ( "error", "No map selected!" )
 			end
 			local mapName = guiGridListGetItemText ( aTabMap.MapList, guiGridListGetSelectedItem( aTabMap.MapList ), 1 )


### PR DESCRIPTION
extra check added to client/gui/admin_maps.lua line 69 to make exception if the source is the search bar editbox.