### PR TITLE
Add a new "restore" button within Editor's "Current Elements" window.

### DIFF
--- a/[editor]/editor_gui/client/currentbrowser.lua
+++ b/[editor]/editor_gui/client/currentbrowser.lua
@@ -35,7 +35,8 @@ function createCurrentBrowser ()
 	--linked to options
 	dialog.autosnap = editingControl.boolean:create{["x"]=12,["y"]=windowHeight-48,["width"]=115,["height"]=30,["relative"]=false,["parent"]=currentBrowserGUI.browser,["label"]="Autosnap camera"}
 	currentBrowserGUI.isolate = guiCreateCheckBox ( 12, windowHeight-24, 115, 30, "Isolate element", false, false, currentBrowserGUI.browser )
-	currentBrowserGUI.close = guiCreateButton ( 132, windowHeight-40, windowWidth, 40, "Close", false, currentBrowserGUI.browser )
+	currentBrowserGUI.restore = guiCreateButton ( 132, windowHeight-40, windowWidth-315, 40, "Restore", false, currentBrowserGUI.browser )
+	currentBrowserGUI.close = guiCreateButton ( 300, windowHeight-40, windowWidth, 40, "Close", false, currentBrowserGUI.browser )
 	guiSetProperty(currentBrowserGUI.browser,"RelativeMinSize","w:0.250000 h:0.400000")
 	--
 	guiSetAlpha ( currentBrowserGUI.browser, 50 )
@@ -51,6 +52,7 @@ function createCurrentBrowser ()
 	currentBrowser.update()
 	addEventHandler ( "onClientGUIClick", currentBrowserGUI.close, closeCurrentBrowser, false )
 	addEventHandler ( "onClientGUIClick", currentBrowserGUI.isolate, currentBrowser.isolateClick, false )
+	addEventHandler ( "onClientGUIClick", currentBrowserGUI.restore, restoreSelectedElement, false )
 	addEventHandler ( "onClientGUISize", currentBrowserGUI.browser, currentBrowser.resized, false )
 	currentBrowserGUI.gridlist:addCallback(currentBrowser.gridlistClick)
 	currentBrowserGUI.gridlist:addDoubleClickCallback(currentBrowser.doubleClick)
@@ -64,7 +66,7 @@ function currentBrowser.resized()
 	currentBrowserGUI.dropdown:setSize(windowWidth,20,windowWidth,200,false)
 	dialog.autosnap:setPosition( 12, windowHeight-48,false )
 	guiSetPosition ( currentBrowserGUI.isolate, 12, windowHeight-24,false )
-	guiSetPosition ( currentBrowserGUI.close, 132, windowHeight-40, false )
+	guiSetPosition ( currentBrowserGUI.close, 300, windowHeight-40, false )
 	guiSetSize ( currentBrowserGUI.close, windowWidth, 40, false )
 	--
 	if not isResizing then
@@ -178,6 +180,7 @@ function currentBrowser.gridlistClick (cellrow)
 	if cellrow ~= 0 then
 		local id = currentBrowserGUI.gridlist:getSelectedText()
 		cSelectedElement = getElementByID ( id )
+		editor_main.selectElement ( cSelectedElement, 2, false, cSelectedElement, cSelectedElement, true)
 		if ( dialog.autosnap:getValue() ) then
 			autoSnap ( cSelectedElement )
 		end
@@ -448,6 +451,17 @@ function closeCurrentBrowser()
 	removeEventHandler ( "onClientGUIWorldClick", root, currentBrowser.searchClick )
 	removeEventHandler ( "onClientElementCreate",root,currentBrowser.prepareSearch )
 	removeEventHandler ( "onClientElementDestroyed",root,currentBrowser.prepareSearch )
+end
+
+function restoreSelectedElement()
+	if cSelectedElement then
+		editor_main.destroySelectedElement()
+		closeCurrentBrowser()
+		
+		setTimer(function()
+			showCurrentBrowser()
+		end, 100, 1)
+	end
 end
 
 function isCurrentBrowserShowing()

--- a/[editor]/editor_gui/meta.xml
+++ b/[editor]/editor_gui/meta.xml
@@ -57,6 +57,7 @@
 	<export function="openPropertiesBox" type="client" />
 	<export function="restoreSaveDialog" type="client" />
 	<export function="stopTest" type="client" />
+	<export function="restoreSelectedElement" type="client" />
 
 	<!-- Browser -->
 	<script src="client/browser/browserList.lua" type="client" />

--- a/[editor]/editor_main/client/main.lua
+++ b/[editor]/editor_main/client/main.lua
@@ -730,7 +730,7 @@ function disableGameHUD()
 end
 
 -- PUBLIC
-function selectElement(element, submode, shortcut, dropreleaseLock, dropclonedrop)
+function selectElement(element, submode, shortcut, dropreleaseLock, dropclonedrop, ignoreProperties)
 	local openProperties
 	submode = submode or g_submode
 
@@ -802,8 +802,10 @@ function selectElement(element, submode, shortcut, dropreleaseLock, dropclonedro
 			createArrowMarker(handle)
 		end
 	else
-		editor_gui.openPropertiesBox( element, false, shortcut )
-		openProperties = true
+		if not ignoreProperties then
+			editor_gui.openPropertiesBox( element, false, shortcut )
+			openProperties = true
+		end
 	end
 
 	triggerServerEvent("doLockElement", element)
@@ -975,7 +977,10 @@ function getMaxSelectDistance()
 	return g_maxSelectDistance
 end
 
-function destroySelectedElement()
+function destroySelectedElement(key)
+	if key then return 
+		editor_gui.restoreSelectedElement()
+	 end
 	if g_selectedElement then
 		local element = g_selectedElement
 		dropElement(false)


### PR DESCRIPTION
Although this commit is for #374 -- it also fixes the problems in #301 (without major changes to object deletions (for not e.g. replacing the dimension method with something else))

Knowing that this commit is also compatible to redo/undo actions*
![image](https://user-images.githubusercontent.com/30158626/212256513-b6460477-ce75-4f1b-84ab-d6cbc8f03419.png)
