### PR TITLE
Fix freecam mouse & key input by ignoring it when MTA window not focused

### DIFF
--- a/[editor]/freecam/freecam.lua
+++ b/[editor]/freecam/freecam.lua
@@ -45,6 +45,9 @@ function getKeyState(key)
 	if isMTAWindowActive() then
 		return false
 	end
+	if not isMTAWindowFocused() then
+		return false
+	end
 	if key == "lshift" or key == "lalt" or key == "arrow_u" or key == "arrow_d" or key == "arrow_l" or key == "arrow_r" then
 		return mta_getKeyState(key)
 	end
@@ -216,7 +219,7 @@ local function freecamMouse (cX,cY,aX,aY)
 	--ignore mouse movement if the cursor or MTA window is on
 	--and do not resume it until at least 5 frames after it is toggled off
 	--(prevents cursor mousemove data from reaching this handler)
-	if isCursorShowing() or isMTAWindowActive() then
+	if isCursorShowing() or isMTAWindowActive() or (not isMTAWindowFocused()) then
 		mouseFrameDelay = 5
 		return
 	elseif mouseFrameDelay > 0 then

--- a/[editor]/freecam/meta.xml
+++ b/[editor]/freecam/meta.xml
@@ -1,5 +1,6 @@
 <meta>
 	<info author="eAi, QA Team" description="This resource provides a 'free' controllable camera to 'fly' around the map with" version="1.1" />
+	<min_mta_version client="1.5.9-9.21313.0"/>
 	<script src="freecam.lua" type="client" />
 	<script src="freecam_server.lua" type="server" />
 	<!-- server functions -->


### PR DESCRIPTION
This PR makes the freecam (used mainly by map `editor`) ignore all mouse & key input when the MTA window is not focused, using the new https://wiki.multitheftauto.com/wiki/IsMTAWindowFocused function (since 1.5.9 r21313).
Meta.xml min_mta_version client updated.

This corrects the annoying behavior that you could reproduce by doing this:
1. play in windowed mode
2. open an application like calculator or another window, place it ontop of MTA window
3. pass your mouse on the MTA window, freecam would go crazy