### PR TITLE
scoreboard: Trigger events improvements

### DIFF
--- a/[gameplay]/scoreboard/dxscoreboard_client.lua
+++ b/[gameplay]/scoreboard/dxscoreboard_client.lua
@@ -69,9 +69,8 @@ addEventHandler( "onClientResourceStart", resourceRoot,
 		bindKey( settingsKey, "down", "Open scoreboard settings", "1" )
 
 		addEventHandler( "onClientRender", root, drawScoreboard )
-		triggerServerEvent( "onClientDXScoreboardResourceStart", root )
 		readScoreboardSettings()
-		triggerServerEvent( "requestServerInfo", root )
+		triggerServerEvent( "requestServerInfo", localPlayer )
 
 		colorPicker.constructor()
 	end
@@ -87,7 +86,7 @@ function sendServerInfo( output )
 	serverInfo = output
 end
 addEvent( "sendServerInfo", true )
-addEventHandler( "sendServerInfo", resourceRoot, sendServerInfo )
+addEventHandler( "sendServerInfo", root, sendServerInfo )
 
 function toggleScoreboard( _, state )
 	state = iif( state == "1", true, false )
@@ -218,7 +217,7 @@ function doDrawScoreboard( rtPass, onlyAnim, sX, sY )
 						if not (windowSettings and isElement( windowSettings )) then
 							showCursor( false )
 						end
-						triggerServerEvent( "requestServerInfo", root )
+						triggerServerEvent( "requestServerInfo", localPlayer )
 					end
 					scoreboardDrawn = true
 				end
@@ -791,7 +790,7 @@ end
 
 
 addEvent( "doScoreboardAddColumn", true )
-addEventHandler( "doScoreboardAddColumn", resourceRoot,
+addEventHandler( "doScoreboardAddColumn", root,
 	function ( name, width, friendlyName, priority, fromResource, isImage, imageW, imageH )
 		scoreboardAddColumn( name, width, friendlyName, priority, nil, fromResource, isImage, imageW, imageH )
 	end

--- a/[gameplay]/scoreboard/dxscoreboard_exports.lua
+++ b/[gameplay]/scoreboard/dxscoreboard_exports.lua
@@ -201,13 +201,20 @@ function scoreboardGetColumnCount()
 	return #scoreboardColumns
 end
 
-function onClientDXScoreboardResourceStart()
-	for key, column in ipairs( scoreboardColumns ) do
-		triggerClientEvent( client, "doScoreboardAddColumn", root, column.name, column.width, column.friendlyName, column.priority, nil, column.isImage, column.imageW, column.imageH )
+function onPlayerResourceStartScoreboard(startedResource)
+	local validResource = startedResource == resource
+
+	if not validResource then
+		return false
+	end
+
+	for columnID = 1, #scoreboardColumns do
+		local columnData = scoreboardColumns[columnID]
+
+		triggerClientEvent(source, "doScoreboardAddColumn", source, columnData.name, columnData.width, columnData.friendlyName, columnData.priority, nil, columnData.isImage, columnData.imageW, columnData.imageH)
 	end
 end
-addEvent( "onClientDXScoreboardResourceStart", true )
-addEventHandler( "onClientDXScoreboardResourceStart", resourceRoot, onClientDXScoreboardResourceStart )
+addEventHandler("onPlayerResourceStart", root, onPlayerResourceStartScoreboard)
 
 function requestServerInfo()
 	local mapmanager = getResourceFromName( "mapmanager" )
@@ -230,10 +237,10 @@ function requestServerInfo()
 			output.map = getResourceInfo( map, "name" ) or getResourceName( map )
 		end
 	end
-	triggerClientEvent( client, "sendServerInfo", root, output )
+	triggerClientEvent( client, "sendServerInfo", client, output )
 end
 addEvent( "requestServerInfo", true )
-addEventHandler( "requestServerInfo", resourceRoot, requestServerInfo )
+addEventHandler( "requestServerInfo", root, requestServerInfo )
 
 function removeResourceScoreboardColumns( resource )
 	if resourceColumns[resource] then

--- a/[gameplay]/scoreboard/meta.xml
+++ b/[gameplay]/scoreboard/meta.xml
@@ -2,12 +2,11 @@
 	<min_mta_version server="1.5.8-9.20957"/>
 	<info author="Awwu" type="script" name="Scoreboard" description="DirectX scoreboard resource" showInResourceBrowser="true" version="2.7.2"/>
 
-	<script src="dxscoreboard_shared.lua" type="server" />
+	<script src="dxscoreboard_shared.lua" type="shared" />
 	<script src="dxscoreboard_exports.lua" type="server" />
 	<script src="dxscoreboard_http.lua" type="server" />
 	<script src="dxscoreboard_client.lua" type="client" />
 	<script src="dxscoreboard_clientsettings.lua" type="client" />
-	<script src="dxscoreboard_shared.lua" type="client" />
 	<script src="dxscoreboard_countries.lua" type="server" />
 
 	<script src="colorpicker/colorpicker.lua" type="client" />

--- a/[gameplay]/scoreboard/meta.xml
+++ b/[gameplay]/scoreboard/meta.xml
@@ -1,4 +1,5 @@
 <meta>
+	<min_mta_version server="1.5.8-9.20957"/>
 	<info author="Awwu" type="script" name="Scoreboard" description="DirectX scoreboard resource" showInResourceBrowser="true" version="2.7.2"/>
 
 	<script src="dxscoreboard_shared.lua" type="server" />


### PR DESCRIPTION
- Replaced client triggerServerEvent with onPlayerResourceStart.
- Changed event sources from root to lowest possible element.
- Use shared type for **dxscoreboard_shared.lua** in meta.xml, instead of twice defining it.