### PR TITLE
rustlerbombs: Remove unnecessary parameter

### DIFF
--- a/[gameplay]/rustlerbombs/client.lua
+++ b/[gameplay]/rustlerbombs/client.lua
@@ -16,7 +16,7 @@ function drawHud()
 	end
 end
 
-function dropGliderBomb(rustler)
+function dropGliderBomb()
 	if not isElement(rustler) then
 		return
 	end
@@ -68,7 +68,7 @@ function dropGliderBomb(rustler)
 end
 
 function gliderBomb()
-	dropGliderBomb(rustler)
+	dropGliderBomb()
 end
 
 function exitMode()


### PR DESCRIPTION
There was an unnecessary parameter "rustler" in the dropGliderBomb function which made the linter unhappy. As there's already a local variable defined to hold the rustler the player is in which is actually being used I have removed this parameter.