### PR TITLE
ip2c: Add safety checks to exported function arguments

### DIFF
--- a/[admin]/admin2/server/admin_server.lua
+++ b/[admin]/admin2/server/admin_server.lua
@@ -154,7 +154,9 @@ function updatePlayerCountry(player)
     local isIP2CResourceRunning = getResourceFromName( "ip2c" )
 	isIP2CResourceRunning = isIP2CResourceRunning and getResourceState( isIP2CResourceRunning ) == "running"
     aPlayers[player].country = isIP2CResourceRunning and exports.ip2c:getPlayerCountry(player) or false
-    aPlayers[player].countryname = isIP2CResourceRunning and exports.ip2c:getCountryName(aPlayers[player].country) or false
+    if aPlayers[player].country then
+        aPlayers[player].countryname = isIP2CResourceRunning and exports.ip2c:getCountryName(aPlayers[player].country) or false
+    end
 end
 
 function aPlayerInitialize(player)

--- a/[admin]/ip2c/meta.xml
+++ b/[admin]/ip2c/meta.xml
@@ -7,14 +7,6 @@
 
     <script src="shared.lua" type="shared"/>
     <export function="getCountryName" type="shared"/>
-
-	<!--
-		Allow these rights by typing the following into the server or client console:
-		aclrequest allow acpanel all
-	-->
-	<aclrequest>
-        <right name="function.fetchRemote" access="true"></right>
-	</aclrequest>
     
     <file src="client/images/flags/ad.png" />
     <file src="client/images/flags/ae.png" />

--- a/[admin]/ip2c/meta.xml
+++ b/[admin]/ip2c/meta.xml
@@ -7,6 +7,14 @@
 
     <script src="shared.lua" type="shared"/>
     <export function="getCountryName" type="shared"/>
+
+	<!--
+		Allow these rights by typing the following into the server or client console:
+		aclrequest allow acpanel all
+	-->
+	<aclrequest>
+        <right name="function.fetchRemote" access="true"></right>
+	</aclrequest>
     
     <file src="client/images/flags/ad.png" />
     <file src="client/images/flags/ae.png" />

--- a/[admin]/ip2c/server.lua
+++ b/[admin]/ip2c/server.lua
@@ -20,6 +20,7 @@ local IP2C_UPDATE_INTERVAL_SECONDS = 60 * 60 * 24 * 1	-- Update no more than onc
 
 -- [Exported]
 function getPlayerCountry ( player )
+	if not (isElement(player) and getElementType(player) == "player") then return false end
 	if not loadIPGroupsIsReady() then return false end
     local ip = getPlayerIP(player)
 	local ip_group = tonumber ( gettok ( ip, 1, 46 ) )

--- a/[admin]/ip2c/shared.lua
+++ b/[admin]/ip2c/shared.lua
@@ -255,5 +255,8 @@ local countryListAlpha2 = {
 
 -- [Exported]
 function getCountryName( country )
+    if type(country) ~= "string" then
+        return "Invalid country code"
+    end
 	return countryListAlpha2[ (string.upper(country)) ] or "Unknown"
 end


### PR DESCRIPTION
Adds safety checks to arguments of `getCountryName( country )` and `getPlayerCountry ( player )`.

Also fixes `admin2` calling `getCountryName(aPlayers[player].country)` without checking if the country code is set. This would always trigger an error when playing on LAN as ip2c can't get any country from your local ip.