### PR TITLE
admin2: added missing set nick functionality

### DIFF
--- a/[admin]/admin2/client/main/admin_players.lua
+++ b/[admin]/admin2/client/main/admin_players.lua
@@ -193,7 +193,7 @@ function aPlayersTab.onClientClick(button)
                 elseif (source == aPlayersTab.Spectate) then
                     aSpectate(player)
                 elseif (source == aPlayersTab.SetNick) then
-                    local nick = inputBox("Set nick", "Enter new nickname for " .. name)
+                    local nick = inputBox("Set nick", "Enter new nickname for " .. name, name)
                     if (nick) then
                         triggerServerEvent("aPlayer", localPlayer, player, "setnick", nick)
                     end

--- a/[admin]/admin2/conf/messages.xml
+++ b/[admin]/admin2/conf/messages.xml
@@ -35,6 +35,11 @@
       <player>You have been unfrozen by $admin</player>
       <log>ADMIN: $admin has unfrozen $player</log>
     </group>
+    <group action="setnick" r="255" g="100" b="70">
+      <admin>$data's nick has been changed to $player</admin>
+      <player>$admin has changed your nick to $player</player>
+      <log>ADMIN: $admin has changed $data's nick to $player</log>
+    </group>
     <group action="slap" r="235" g="20" b="200">
       <all>$player has been slapped by $admin. ($data HP)</all>
       <log>ADMIN: $admin has slapped $player ($data HP)</log>

--- a/[admin]/admin2/server/admin_functions.lua
+++ b/[admin]/admin2/server/admin_functions.lua
@@ -89,18 +89,18 @@ aFunctions = {
         ["sethealth"] = function(player, health1)
             local health = tonumber(health1)
             if (health) then
-                if (health > 200 or health <= 0) then
+                if (health > 200 or health < 0) then
                     health = 100
                 end
                 return setElementHealth(player, health), health
             else
-                action = false
+                return false
             end
         end,
         ["setarmour"] = function(player, armour1)
             local armour = tonumber(armour1)
             if (armour) then
-                if (armour > 200 or armour <= 0) then
+                if (armour > 200 or armour < 0) then
                     armour = 100
                 end
                 return setPedArmor(player, armour), armour

--- a/[admin]/admin2/server/admin_functions.lua
+++ b/[admin]/admin2/server/admin_functions.lua
@@ -57,6 +57,14 @@ aFunctions = {
             toggleAllControls(player, true, true, false)
             setElementFrozen(player, false)
         end,
+        ["setnick"] = function(player, nick)
+            if (#nick > 0) then
+                local oldnick = getPlayerName(player)
+                return setPlayerName(player, nick), oldnick
+            else
+                return false
+            end
+        end,
         ["shout"] = function(player, text)
             local textDisplay = textCreateDisplay()
             local textItem =


### PR DESCRIPTION
"Set nick" was previously missing any form of functionality beyond opening an input box. This pull request fixes that.

The input box will now correctly default to the current nick of the target player.

aFunction now has a "setnick" function associated in the player section that will change the target player's name as you would expect.

The messages.xml file was updated to include texts for the target player, the admin and the server log upon use. The color values were taken directly from admin1.

Additionally the two neighboring functions "sethealth" and "setarmour" received a minor fix, so that they now accept 0 as the lowest valid input and "sethealth" will no longer display an unintended message when the admin provides a non-number input. If undesired, the other commit can be cherry-picked to keep the current behavior.