### PR TITLE
admin2: forward-ported permissions widget from admin1

### DIFF
--- a/[admin]/admin2/admin_definitions.lua
+++ b/[admin]/admin2/admin_definitions.lua
@@ -55,6 +55,7 @@ enum(
     {
         "SYNC_PLAYER",
         "SYNC_PLAYERS",
+        "SYNC_PLAYERACL",
         "SYNC_RESOURCES",
         "SYNC_RESOURCE",
         "SYNC_ADMINS",

--- a/[admin]/admin2/client/main/admin_players.lua
+++ b/[admin]/admin2/client/main/admin_players.lua
@@ -74,7 +74,7 @@ function aPlayersTab.Create(tab)
     aPlayersTab.Shout = guiCreateButton(0.74, 0.19, 0.12, 0.04, "Shout", true, tab, "shout")
     aPlayersTab.Spectate = guiCreateButton(0.87, 0.19, 0.12, 0.04, "Spectate", true, tab, "spectate")
     aPlayersTab.SetNick = guiCreateButton(0.74, 0.235, 0.12, 0.04, "Set nick", true, tab, "setnick")
-    aPlayersTab.Admin = guiCreateButton(0.87, 0.235, 0.12, 0.04, "Give admin", true, tab, "setgroup")
+    aPlayersTab.Permissions = guiCreateButton(0.87, 0.235, 0.12, 0.04, "Permissions", true, tab, "setgroup")
     aPlayersTab.SlapOptions = guiCreateComboBox(0.76, 0.28, 0.1, 0.04, "0", true, tab)
     local width, height = guiGetSize(aPlayersTab.SlapOptions, false)
     for i = 0, 200, 20 do
@@ -257,14 +257,11 @@ function aPlayersTab.onClientClick(button)
                     end
                 elseif (source == aPlayersTab.WarpPlayer) then
                     aPlayerWarp(player)
-                elseif (source == aPlayersTab.Admin) then
-                    if
-                        (aPlayers[player]["admin"] and
-                            messageBox("Revoke admin rights from " .. name .. "?", MB_WARNING))
-                     then
-                        triggerServerEvent("aPlayer", localPlayer, player, "setgroup", false)
-                    elseif (messageBox("Give admin rights to " .. name .. "?", MB_WARNING)) then
-                        triggerServerEvent("aPlayer", localPlayer, player, "setgroup", true)
+                elseif (source == aPlayersTab.Permissions) then
+                    if (aPlayers[player]['account'] ~= 'guest') then
+                        aPermissions.Show(player)
+                    else
+                        aMessageBox.Show("This player is not logged in!", MB_ERROR, MB_ERROR)
                     end
                 end
             end
@@ -298,7 +295,6 @@ function aPlayersTab.onClientClick(button)
                 guiSetText(aPlayersTab.Groups, "Groups: N/A")
                 guiSetText(aPlayersTab.Mute, "Mute")
                 guiSetText(aPlayersTab.Freeze, "Freeze")
-                guiSetText(aPlayersTab.Admin, "Give admin")
                 guiSetText(aPlayersTab.Health, "Health: 0%")
                 guiSetText(aPlayersTab.Armour, "Armour: 0%")
                 guiSetText(aPlayersTab.Skin, "Skin: N/A")

--- a/[admin]/admin2/client/main/admin_players.lua
+++ b/[admin]/admin2/client/main/admin_players.lua
@@ -261,7 +261,7 @@ function aPlayersTab.onClientClick(button)
                     if (aPlayers[player]['account'] ~= 'guest') then
                         aPermissions.Show(player)
                     else
-                        aMessageBox.Show("This player is not logged in!", MB_ERROR, MB_ERROR)
+                        messageBox("This player is not logged in!", MB_ERROR, MB_ERROR)
                     end
                 end
             end

--- a/[admin]/admin2/client/widgets/admin_permissions.lua
+++ b/[admin]/admin2/client/widgets/admin_permissions.lua
@@ -105,7 +105,7 @@ function aPermissions.ConfirmChange(add)
 
     if (not isElement(player)) then
         aPermissions.Close(false)
-        aMessageBox.Show ( "Player not found!", MB_ERROR, "error")
+        aMessageBox.Show ( "Player not found!", MB_ERROR, MB_ERROR)
         return
     end
 

--- a/[admin]/admin2/client/widgets/admin_permissions.lua
+++ b/[admin]/admin2/client/widgets/admin_permissions.lua
@@ -105,7 +105,7 @@ function aPermissions.ConfirmChange(add)
 
     if (not isElement(player)) then
         aPermissions.Close(false)
-        aMessageBox.Show("Player not found!", MB_ERROR, MB_ERROR)
+        messageBox("Player not found!", MB_ERROR, MB_ERROR)
         return
     end
 
@@ -122,7 +122,7 @@ function aPermissions.ConfirmChange(add)
     local str = add and 'Are you sure you want to add "%s" to the "%s" group?' or 'Are you sure you want to remove "%s" from the "%s" group?'
     str = str:format(getPlayerName(player), groupName)
 
-    return aMessageBox.Show(str, MB_QUESTION, MB_YESNO), groupName, add
+    return messageBox(str, MB_QUESTION, MB_YESNO), groupName, add
 end
 
 function aPermissions.PerformAction(player, groupName, newState)

--- a/[admin]/admin2/client/widgets/admin_permissions.lua
+++ b/[admin]/admin2/client/widgets/admin_permissions.lua
@@ -122,7 +122,7 @@ function aPermissions.ConfirmChange(add)
     local str = add and 'Are you sure you want to add "%s" to the "%s" group?' or 'Are you sure you want to remove "%s" from the "%s" group?'
     str = str:format(getPlayerName(player), groupName)
 
-    return aMessageBox.Show ( str, MB_QUESTION, MB_YESNO, "updatePlayerACLGroup", player, groupName, add), groupName, add
+    return aMessageBox.Show ( str, MB_QUESTION, MB_YESNO ), groupName, add
 end
 
 function aPermissions.PerformAction(player, groupName, newState)

--- a/[admin]/admin2/client/widgets/admin_permissions.lua
+++ b/[admin]/admin2/client/widgets/admin_permissions.lua
@@ -84,12 +84,12 @@ function aPermissions.onClick(button)
             aPermissions.Refresh()
         elseif (source == aPermissions.RemoveGroup) then
             local confirm, groupName, newState = aPermissions.ConfirmChange(false)
-            if confirm then
+            if (confirm) then
                 aPermissions.PerformAction(aPermissions.SelectedPlayer, groupName, newState)
             end
         elseif (source == aPermissions.AddGroup) then
             local confirm, groupName, newState = aPermissions.ConfirmChange(true)
-            if confirm then
+            if (confirm) then
                 aPermissions.PerformAction(aPermissions.SelectedPlayer, groupName, newState)
             end
         elseif (source == aPermissions.AllGroups) then
@@ -105,7 +105,7 @@ function aPermissions.ConfirmChange(add)
 
     if (not isElement(player)) then
         aPermissions.Close(false)
-        aMessageBox.Show ( "Player not found!", MB_ERROR, MB_ERROR)
+        aMessageBox.Show("Player not found!", MB_ERROR, MB_ERROR)
         return
     end
 
@@ -122,19 +122,19 @@ function aPermissions.ConfirmChange(add)
     local str = add and 'Are you sure you want to add "%s" to the "%s" group?' or 'Are you sure you want to remove "%s" from the "%s" group?'
     str = str:format(getPlayerName(player), groupName)
 
-    return aMessageBox.Show ( str, MB_QUESTION, MB_YESNO ), groupName, add
+    return aMessageBox.Show(str, MB_QUESTION, MB_YESNO), groupName, add
 end
 
 function aPermissions.PerformAction(player, groupName, newState)
     local playerAccount = player and aPlayers[player] and aPlayers[player]['account']
-    if playerAccount and (playerAccount ~= 'guest') then
+    if (playerAccount and (playerAccount ~= 'guest')) then
         triggerServerEvent('aPlayer', localPlayer, player, "setgroup", newState, groupName)
     end
 end
 
 function aPermissions.Refresh()
     local player = aPermissions.SelectedPlayer
-    if isElement(player) and aPermissions.PlayerGroups and aPermissions.AllGroups then
+    if (isElement(player) and aPermissions.PlayerGroups and aPermissions.AllGroups) then
         guiGridListClear(aPermissions.PlayerGroups)
         guiGridListClear(aPermissions.AllGroups)
         triggerServerEvent(EVENT_SYNC, localPlayer, SYNC_PLAYERACL, player)

--- a/[admin]/admin2/client/widgets/admin_permissions.lua
+++ b/[admin]/admin2/client/widgets/admin_permissions.lua
@@ -2,7 +2,7 @@
 *
 *   Multi Theft Auto - Admin Panel
 *
-*   client\gui\admin_permissions.lua
+*   client\widgets\admin_permissions.lua
 *
 *   Original File by lil_Toady
 *

--- a/[admin]/admin2/client/widgets/admin_permissions.lua
+++ b/[admin]/admin2/client/widgets/admin_permissions.lua
@@ -1,0 +1,142 @@
+--[[**********************************
+*
+*   Multi Theft Auto - Admin Panel
+*
+*   client\gui\admin_permissions.lua
+*
+*   Original File by lil_Toady
+*
+**************************************]]
+aPermissions = {
+    Form = nil,
+    SelectedPlayer = nil,
+}
+
+addEvent('aPermissionsSync', true)
+addEvent('aOnPermissionsChange', true)
+
+function aPermissions.Show(player)
+    if (not aPermissions.Form) then
+        local x, y = guiGetScreenSize()
+        aPermissions.Form = guiCreateWindow(x / 2 - 200, y / 2 - 125, 400, 250, '', false)
+        guiSetAlpha(aPermissions.Form, 1)
+        
+        aPermissions.LabelYourPerms = guiCreateLabel(0.03, 0.1, 0.35, 0.07, '', true, aPermissions.Form)
+        aPermissions.PlayerGroups = guiCreateGridList(0.03, 0.18, 0.35, 0.68, true, aPermissions.Form)
+        guiGridListAddColumn(aPermissions.PlayerGroups, "Group Name", 0.85)
+        aPermissions.RemoveGroup = guiCreateButton(0.39, 0.18, 0.075, 0.68, '>\n>\n>', true, aPermissions.Form)
+        guiSetEnabled(aPermissions.RemoveGroup, false)
+
+        aPermissions.LabelAllPerms = guiCreateLabel(0.62, 0.1, 0.35, 0.07, "Available groups:", true, aPermissions.Form)
+        aPermissions.AllGroups = guiCreateGridList(0.62, 0.18, 0.35, 0.68, true, aPermissions.Form)
+        guiGridListAddColumn(aPermissions.AllGroups, "Group Name", 0.85)
+        aPermissions.AddGroup = guiCreateButton(0.535, 0.18, 0.075, 0.68, '<\n<\n<', true, aPermissions.Form)
+        guiSetEnabled(aPermissions.AddGroup, false)
+
+        aPermissions.Update = guiCreateButton(0.03, 0.88, 0.435, 0.09, "Refresh", true, aPermissions.Form)
+        aPermissions.Hide = guiCreateButton(0.535, 0.88, 0.435, 0.09, "Close", true, aPermissions.Form)
+        
+        addEventHandler(EVENT_SYNC, localPlayer, aPermissions.onSync)
+        addEventHandler("onClientGUIClick", aPermissions.Form, aPermissions.onClick)
+        
+        --Register With Admin Form
+        aRegister("PlayerPermissions", aPermissions.Form, aPermissions.Show, aPermissions.Close)
+    end
+    guiSetText(aPermissions.Form, ("Manage %s's permissions"):format(getPlayerName(player)))
+    guiSetText(aPermissions.LabelYourPerms, ("%s's groups:"):format(getPlayerName(player)))
+    aPermissions.SelectedPlayer = player
+    aPermissions.Refresh()
+    guiSetVisible(aPermissions.Form, true)
+    guiBringToFront(aPermissions.Form)
+end
+
+function aPermissions.onSync(type, permissions)
+    if (type == SYNC_PLAYERACL) then
+        if (source == aPermissions.SelectedPlayer) then
+            guiGridListClear(aPermissions.PlayerGroups)
+            guiGridListClear(aPermissions.AllGroups)
+            for group, state in pairs(permissions) do
+                local gridlist = state and aPermissions.PlayerGroups or aPermissions.AllGroups
+                guiGridListAddRow(gridlist, group)
+            end
+        end
+    end
+end
+
+function aPermissions.Close(destroy)
+    if (destroy) then
+        if (aPermissions.Form) then
+            destroyElement(aPermissions.Form)
+            aPermissions.Form = nil
+            removeEventHandler(EVENT_SYNC, localPlayer, aPermissions.onSync)
+        end
+    else
+        guiSetVisible(aPermissions.Form, false)
+    end
+    aPermissions.SelectedPlayer = nil
+end
+
+function aPermissions.onClick(button)
+    if (button == 'left') then
+        if (source == aPermissions.Hide) then
+            aPermissions.Close()
+        elseif (source == aPermissions.Update) then
+            aPermissions.Refresh()
+        elseif (source == aPermissions.RemoveGroup) then
+            local confirm, groupName, newState = aPermissions.ConfirmChange(false)
+            if confirm then
+                aPermissions.PerformAction(aPermissions.SelectedPlayer, groupName, newState)
+            end
+        elseif (source == aPermissions.AddGroup) then
+            local confirm, groupName, newState = aPermissions.ConfirmChange(true)
+            if confirm then
+                aPermissions.PerformAction(aPermissions.SelectedPlayer, groupName, newState)
+            end
+        elseif (source == aPermissions.AllGroups) then
+            guiSetEnabled(aPermissions.AddGroup, guiGridListGetSelectedItem(aPermissions.AllGroups) > -1)
+        elseif (source == aPermissions.PlayerGroups) then
+            guiSetEnabled(aPermissions.RemoveGroup, guiGridListGetSelectedItem(aPermissions.PlayerGroups) > -1)
+        end
+    end
+end
+
+function aPermissions.ConfirmChange(add)
+    local player = aPermissions.SelectedPlayer
+
+    if (not isElement(player)) then
+        aPermissions.Close(false)
+        aMessageBox.Show ( "Player not found!", MB_ERROR, "error")
+        return
+    end
+
+    local gridlist = add and aPermissions.AllGroups or aPermissions.PlayerGroups
+    
+    local selected = guiGridListGetSelectedItem(gridlist)
+
+    if (selected <= -1) then
+        return
+    end
+    
+    local groupName = guiGridListGetItemText(gridlist, selected, 1)
+
+    local str = add and 'Are you sure you want to add "%s" to the "%s" group?' or 'Are you sure you want to remove "%s" from the "%s" group?'
+    str = str:format(getPlayerName(player), groupName)
+
+    return aMessageBox.Show ( str, MB_QUESTION, MB_YESNO, "updatePlayerACLGroup", player, groupName, add), groupName, add
+end
+
+function aPermissions.PerformAction(player, groupName, newState)
+    local playerAccount = player and aPlayers[player] and aPlayers[player]['account']
+    if playerAccount and (playerAccount ~= 'guest') then
+        triggerServerEvent('aPlayer', localPlayer, player, "setgroup", newState, groupName)
+    end
+end
+
+function aPermissions.Refresh()
+    local player = aPermissions.SelectedPlayer
+    if isElement(player) and aPermissions.PlayerGroups and aPermissions.AllGroups then
+        guiGridListClear(aPermissions.PlayerGroups)
+        guiGridListClear(aPermissions.AllGroups)
+        triggerServerEvent(EVENT_SYNC, localPlayer, SYNC_PLAYERACL, player)
+    end
+end

--- a/[admin]/admin2/conf/messages.xml
+++ b/[admin]/admin2/conf/messages.xml
@@ -93,14 +93,14 @@
       <log>ADMIN: $admin has given a jetpack to $player</log>
     </group>
     <group action="adminr" r="255" g="0" b="0">
-      <admin>$player's admin rights have been revoked</admin>
-      <player>$admin has revoked your admin rights</player>
-      <log>ADMIN: $admin has revoked admin privilegies from $player</log>
+      <admin>$player has been removed from the $data group</admin>
+      <player>$admin has removed you from the $data group</player>
+      <log>ADMIN: $admin has removed $player from the $data group</log>
     </group>
     <group action="admina" r="0" g="255" b="0">
-      <admin>$player has been given admin rights</admin>
-      <player>$admin has given you admin rights</player>
-      <log>ADMIN: $admin has given admin privilegies to $player</log>
+      <admin>$player has been added to the $data group</admin>
+      <player>$admin has added you to the $data group</player>
+      <log>ADMIN: $admin has added $player to the $data group</log>
     </group>
     <group action="givevehicle" r="0" g="255" b="0">
       <admin>$player has been given a '$data'</admin>

--- a/[admin]/admin2/meta.xml
+++ b/[admin]/admin2/meta.xml
@@ -54,6 +54,7 @@
     <script src="client/widgets/admin_inputbox.lua" type="client" />
     <script src="client/widgets/admin_color.lua" type="client" />
     <script src="client/widgets/admin_performance.lua" type="client" />
+    <script src="client/widgets/admin_permissions.lua" type="client" />
     <script src="client/widgets/admin_messages.lua" type="client" />
     <script src="client/widgets/admin_message.lua" type="client" />
     <script src="client/widgets/admin_spectator.lua" type="client" />

--- a/[admin]/admin2/server/admin_functions.lua
+++ b/[admin]/admin2/server/admin_functions.lua
@@ -184,33 +184,21 @@ aFunctions = {
                 end
             end
         end,
-        ["setgroup"] = function(player, data)
-            -- NEEDS CHECKING
+        ["setgroup"] = function(player, data, groupName)
             local account = getPlayerAccount(player)
             if (not isGuestAccount(account)) then
-                local group = aclGetGroup(data)
+                local group = aclGetGroup(groupName)
                 if (group) then
                     if (data == true) then
                         aclGroupAddObject(group, "user." .. getAccountName(account))
-                        return true, "admina"
+                        triggerEvent(EVENT_SYNC, source, SYNC_PLAYERACL, player)
+                        return "admina", groupName
                     elseif (data == false) then
                         aclGroupRemoveObject(group, "user." .. getAccountName(account))
                         aPlayers[player]["chat"] = false
-                        return true, "adminr"
+                        triggerEvent(EVENT_SYNC, source, SYNC_PLAYERACL, player)
+                        return "adminr", groupName
                     end
-                    for id, p in ipairs(getElementsByType("player")) do
-                        if (hasObjectPermissionTo(p, "general.adminpanel")) then
-                            triggerEvent("aSync", p, "admins")
-                        end
-                    end
-                else
-                    outputChatBox(
-                        "Error - Admin group not initialized. Please reinstall admin resource.",
-                        source,
-                        255,
-                        0,
-                        0
-                    )
                 end
             else
                 outputChatBox("Error - Player is not logged in.", source, 255, 100, 100)

--- a/[admin]/admin2/server/admin_sync.lua
+++ b/[admin]/admin2/server/admin_sync.lua
@@ -42,6 +42,21 @@ addEventHandler(
                 tableOut[player].country = aPlayers[player]["country"]
                 tableOut[player].countryname = aPlayers[player]["countryname"]
             end
+        elseif (type == SYNC_PLAYERACL) then
+            local player = data
+            if isElement(player) then
+                theSource = player
+                local ignoredGroups = {
+                    ['Everyone'] = true,
+                    ['autoGroup_irc'] = true,
+                }
+                for _, v in ipairs(aclGroupList()) do
+                    local groupName = aclGroupGetName(v)
+                    if (not ignoredGroups[groupName]) then
+                        tableOut[groupName] = isObjectInACLGroup('user.'..getAccountName(getPlayerAccount(player)), v)
+                    end
+                end
+            end
         elseif (type == SYNC_RESOURCES) then
             tableOut = {}
             local resourceTable = getResources()


### PR DESCRIPTION
admin2 currently has a non-functional "Give admin" button in the players tab. Not only is it not functional, but it's also a considerable downgrade from admin1's quick player permission management. This pull request brings admin1's permission widget over to admin2.

Since admin2 is structured slightly differently and I'm not very well-versed in working with either of the resources I'm not 100% sure about whether I adjusted for those differences correctly in the places I had to, but feedback from the developer discord so far has been positive. Particularly the data transmission between server and client and refreshing the displayed data might need checking, because I hardly know how it's expected to be used correctly.