### PR TITLE
parachute: Added missing min_mta_version for server to fix warning

### DIFF
--- a/[gameplay]/parachute/meta.xml
+++ b/[gameplay]/parachute/meta.xml
@@ -1,7 +1,7 @@
 <meta>
 	<info author="Jax + Talidan" description="Parachutes script" version="1.0.1"/>
 
-	<min_mta_version client="1.5.5-9.13846" />
+	<min_mta_version server="1.5.5-9.13846" client="1.5.5-9.13846" />
 
 	<script src="utility.lua" type="client"/>
 	<script src="parachute.lua"/>


### PR DESCRIPTION
This fixes the following warning:
```
[2023-05-27 19:02:51] WARNING: [gameplay]\parachute\parachute.lua:18: <min_mta_version> section in the meta.xml is incorrect or missing (expected at least server 1.3.0-9.04570 because a send list is being used)
[2023-05-27 19:03:04] WARNING: [gameplay]\parachute\parachute.lua:32: <min_mta_version> section in the meta.xml is incorrect or missing (expected at least server 1.3.0-9.04570 because a send list is being used)
```