### PR TITLE
votemanager: changed 'not x == y' to 'x ~= y' to appease lint

### DIFF
--- a/[managers]/votemanager/votemanager_polls.lua
+++ b/[managers]/votemanager/votemanager_polls.lua
@@ -530,7 +530,7 @@ function voteBetweenModes(...)
 				i = i + 1
 			end
 		else
-			if exports.mapmanager:isGamemode(gamemode) and not exports.mapmanager:getRunningGamemode() == gamemode then
+			if exports.mapmanager:isGamemode(gamemode) and exports.mapmanager:getRunningGamemode() ~= gamemode then
 				local gamemodeName = getResourceInfo(gamemode, "name") or getResourceName(gamemode)
 				table.insert(poll,{gamemodeName, call, getResourceFromName("mapmanager"), "changeGamemode", gamemode})
 				i = i + 1


### PR DESCRIPTION
Lint doesn't like [this line](https://github.com/multitheftauto/mtasa-resources/blame/b4119cca4665d63a3043f14c1624ce9c96700b96/%5Bmanagers%5D/votemanager/votemanager_polls.lua#L533)
`if exports.mapmanager:isGamemode(gamemode) and not exports.mapmanager:getRunningGamemode() == gamemode then`

It responds with:
> [managers]/votemanager/votemanager_polls.lua:533:51: Error prone negation: negation is executed before relational operator.

Hopefully it likes this new negationless line better.
`if exports.mapmanager:isGamemode(gamemode) and exports.mapmanager:getRunningGamemode() ~= gamemode then`