### PR TITLE
Add limit to admin chat message length

### DIFF
--- a/[admin]/admin/admin_definitions.lua
+++ b/[admin]/admin/admin_definitions.lua
@@ -19,6 +19,9 @@ function enum ( args, prefix )
 	end
 end
 
+-- MISC DEFINITIONS
+ADMIN_CHAT_MAXLENGTH = 225
+
 -- EVENT CALLS
 
 enum

--- a/[admin]/admin/client/gui/admin_main.lua
+++ b/[admin]/admin/client/gui/admin_main.lua
@@ -333,6 +333,7 @@ y=y+B  aTab1.VehicleHealth	= guiCreateLabel ( 0.26, y, 0.25, 0.04, "Vehicle Heal
 						  guiGridListAddColumn ( aTab5.AdminPlayers, "Admins", 0.90 )
 		aTab5.AdminChatSound	= guiCreateCheckBox ( 0.79, 0.86, 0.18, 0.04, "Play Sound", true, true, aTab5.Tab )
 		aTab5.AdminText		= guiCreateEdit ( 0.03, 0.92, 0.80, 0.06, "", true, aTab5.Tab )
+		guiEditSetMaxLength(aTab5.AdminText, ADMIN_CHAT_MAXLENGTH)
 		aTab5.AdminSay		= guiCreateButton ( 0.85, 0.92, 0.08, 0.06, "Say", true, aTab5.Tab )
 		aTab5.AdminChatHelp	= guiCreateButton ( 0.94, 0.92, 0.03, 0.06, "?", true, aTab5.Tab )
 

--- a/[admin]/admin/server/admin_server.lua
+++ b/[admin]/admin/server/admin_server.lua
@@ -1631,6 +1631,9 @@ end )
 
 addEvent ( "aAdminChat", true )
 addEventHandler ( "aAdminChat", root, function ( chat )
+	if #chat > ADMIN_CHAT_MAXLENGTH then
+		return
+	end
 	if checkClient( true, source, 'aAdminChat' ) then return end
 	for id, player in ipairs(getElementsByType("player")) do
 		if ( aPlayers[player]["chat"] ) then

--- a/[admin]/admin2/admin_definitions.lua
+++ b/[admin]/admin2/admin_definitions.lua
@@ -21,6 +21,9 @@ function enum(args, prefix)
     end
 end
 
+-- MISC DEFINITIONS
+ADMIN_CHAT_MAXLENGTH = 225
+
 -- EVENT CALLS
 
 enum(

--- a/[admin]/admin2/client/main/admin_chat.lua
+++ b/[admin]/admin2/client/main/admin_chat.lua
@@ -23,6 +23,7 @@ function aChatTab.Create(tab)
     aChatTab.AdminChatSound = guiCreateCheckBox(0.81, 0.83, 0.18, 0.04, "Play Sound", aGetSetting("adminChatSound"), true, tab)
     aChatTab.AdminChatOutput = guiCreateCheckBox(0.81, 0.87, 0.18, 0.04, "Output", aGetSetting("adminChatOutput"), true, tab)
     aChatTab.AdminText = guiCreateEdit(0.01, 0.92, 0.78, 0.06, "", true, tab)
+    guiEditSetMaxLength(aChatTab.AdminText, ADMIN_CHAT_MAXLENGTH)
     aChatTab.AdminSay = guiCreateButton(0.80, 0.92, 0.19, 0.06, "Say", true, tab)
 
     addEventHandler("aClientAdminChat", root, aChatTab.onClientAdminChat)

--- a/[admin]/admin2/server/admin_server.lua
+++ b/[admin]/admin2/server/admin_server.lua
@@ -477,7 +477,7 @@ addEventHandler(
     "aAdminChat",
     root,
     function(chat)
-        if #chat >= ADMIN_CHAT_MAXLENGTH then
+        if #chat > ADMIN_CHAT_MAXLENGTH then
             return
         end
         for id, player in ipairs(getElementsByType("player")) do

--- a/[admin]/admin2/server/admin_server.lua
+++ b/[admin]/admin2/server/admin_server.lua
@@ -477,6 +477,9 @@ addEventHandler(
     "aAdminChat",
     root,
     function(chat)
+        if #chat >= ADMIN_CHAT_MAXLENGTH then
+            return
+        end
         for id, player in ipairs(getElementsByType("player")) do
             if (aPlayers[player]["chat"]) then
                 triggerClientEvent(player, "aClientAdminChat", source, chat)


### PR DESCRIPTION
Fixes #373 

Limit is 225 characters: the max chatbox message length, minus 7 for "ADMIN> ", minus 22 (max length for a player name), minus 2 (for ": ").