### PR TITLE
Add option to disable default report system.

### DIFF
--- a/[admin]/admin/client/gui/admin_report.lua
+++ b/[admin]/admin/client/gui/admin_report.lua
@@ -4,7 +4,7 @@
 *
 *	gui\admin_report.lua
 *
-*	Original File by lil_Toady
+*	Original File by lil_Toady|CArg22
 *
 **************************************]]
 
@@ -58,8 +58,6 @@ function aReport ( )
 	guiBringToFront ( aReportForm )
 	showCursor ( true )
 end
-addCommandHandler ( "report", aReport )
-
 
 function aReportClose ( )
 	if ( aReportForm ) then
@@ -171,3 +169,10 @@ function aClientReportClick ( button )
 		end
 	end
 end
+
+addEvent("aClientReports",true)
+addEventHandler("aClientReports",resourceRoot,
+	function( )
+		aReport ( )
+	end
+)

--- a/[admin]/admin/meta.xml
+++ b/[admin]/admin/meta.xml
@@ -18,6 +18,7 @@
   <script src="server/admin_ACL.lua" />
   <script src="server/admin_settings.lua" />
   <script src="server/admin_screenshot.lua" />
+  <script src="server/admin_report.lua" />
   <script src="server/http/admin_http.lua" />
   <script src="client/admin_clientprefs.lua" type="client" cache="false" />
   <script src="client/admin_client.lua" type="client" cache="false" />
@@ -175,6 +176,11 @@
           				friendlyname="Admin chat command name"
           				desc="The command name for admin chat."
           				/>
+
+		<setting name="*reportsEnabled" value="false"
+					friendlyname="Whatever reports are enabled"
+					desc="Set to true to enable default reporting system"
+					/>
 
  </settings>
 </meta>

--- a/[admin]/admin/meta.xml
+++ b/[admin]/admin/meta.xml
@@ -177,7 +177,7 @@
           				desc="The command name for admin chat."
           				/>
 
-		<setting name="*reportsEnabled" value="false"
+		<setting name="*reportsEnabled" value="true"
 					friendlyname="Whatever reports are enabled"
 					desc="Set to true to enable default reporting system"
 					/>

--- a/[admin]/admin/server/admin_report.lua
+++ b/[admin]/admin/server/admin_report.lua
@@ -1,0 +1,15 @@
+--[[**********************************
+*
+*	Multi Theft Auto - Admin Panel
+*
+*	admin_reports.lua
+*
+*	Original File by CArg22
+*
+**************************************]]
+
+if ( get("reportsEnabled") == "true" ) or true then
+	addCommandHandler ( "report", function( plr ) 
+        triggerClientEvent(admin, "aClientReports", resourceRoot )
+    end )
+end

--- a/[admin]/admin/server/admin_server.lua
+++ b/[admin]/admin/server/admin_server.lua
@@ -1483,6 +1483,12 @@ function ( action, data )
 		return
 	end
 	if ( action == "new" ) then
+
+		-- Do not let players create new reports only, allow to read already existing ones.
+		if ( get("reportsEnabled") ~= "true" ) then
+			return
+		end
+
 		local time = getRealTime()
 		local id = #aReports + 1
 		aReports[id] = {}


### PR DESCRIPTION
Adds option "reportsEnabled" that can be used to disable or enabled default reports. Often servers are implementing this kind of system by themself so to do not duplicate functionality they can easily disable default report system.