### PR TITLE
playerblips: Fixed that the resource "playercolors" should be activated for teams

### DIFF
--- a/[gameplay]/playerblips/server/main.lua
+++ b/[gameplay]/playerblips/server/main.lua
@@ -13,7 +13,7 @@ local function resourceStart()
 	end
 
 	local playercolorsResource = getResourceFromName("playercolors")
-	if playercolorsResource and getResourceState(playercolorsResource) ~= "running" then
+	if playercolorsResource and getResourceState(playercolorsResource) ~= "running" and not useTeams then
 		outputDebugString("playerblips: playercolors resource not running; using blip_color. Restart this resource after starting playercolors.", 4, 255, 125, 0)
 		useNametags = false
 	end


### PR DESCRIPTION
The reason for this pull request is because the resource did not work the way I wanted it to. Only after I had a closer look at the code I realized that you can configure the playerblips resource in the `meta.xml`. Because I wanted the playerblips resource to take over the team colors that I have in my code, but that didn't happen. And since the server log said to activate the playercolors resource, I did it, but it didn't help. Only after I deactivated the playercolors resource and set "`use_team_colors`" to "`true`" did it work as expected. 
Anyway, the playercolors resource only makes sense if you want to have random player nametag colors, which makes no sense for teams, since teams can only have one color.