### PR TITLE
Display speedometer at resource start

### DIFF
--- a/[gameplay]/speedometer/client.lua
+++ b/[gameplay]/speedometer/client.lua
@@ -80,3 +80,11 @@ function integrityCheck()
     end
 end
 addEventHandler("onClientPlayerWasted", localPlayer, integrityCheck)
+
+addEventHandler("onClientResourceStart", resourceRoot,
+    function()
+        if isPedInVehicle(localPlayer) then
+            enterHandler(getPedOccupiedVehicle(localPlayer))
+        end
+    end
+)


### PR DESCRIPTION
This pull request adds a small piece of code to the speedometer resource that checks on start to see if the player is in this vehicle, and if so, displays the speedometer. Closes #477