### PR TITLE
Fixed that the GUI window of the resource "internetradio" collides with the GUI window of the resource "helpmanager"

### DIFF
--- a/[gameplay]/internetradio/client.lua
+++ b/[gameplay]/internetradio/client.lua
@@ -153,7 +153,7 @@ function openGUI()
 end
 addEvent("Speaker.openInterface", true)
 addEventHandler("Speaker.openInterface", root, openGUI)
-bindKey("F9", "down", openGUI)
+bindKey("F3", "down", openGUI)
 
 function clickEvent()
 	if (source == setBtn) then


### PR DESCRIPTION
This pull request refers to this issue (fixes #497) where the GUI window of the resource "internetradio" collides with the GUI window of the resource "helpmanager".