### PR TITLE
admin: Fixed that double clicking on a resource without setting opened the GUI settings window

### DIFF
--- a/[admin]/admin/client/gui/admin_main.lua
+++ b/[admin]/admin/client/gui/admin_main.lua
@@ -20,6 +20,7 @@ aLastSync = 0
 aResources = {}
 
 local serverPassword = 'None'
+local hasResourceSetting
 
 function guiComboBoxAdjustHeight ( combobox, itemcount )
     if getElementType ( combobox ) ~= "gui-combobox" or type ( itemcount ) ~= "number" then error ( "Invalid arguments @ 'guiComboBoxAdjustHeight'", 2 ) end
@@ -970,7 +971,9 @@ end
 function aClientDoubleClick ( button )
 	if ( source == aTab2.ResourceList ) then
 		if ( guiGridListGetSelectedItem ( aTab2.ResourceList ) ~= -1 ) then
-			aManageSettings ( guiGridListGetItemText ( aTab2.ResourceList, guiGridListGetSelectedItem( aTab2.ResourceList ), 1 ) )
+			if hasResourceSetting then
+				aManageSettings ( guiGridListGetItemText ( aTab2.ResourceList, guiGridListGetSelectedItem( aTab2.ResourceList ), 1 ) )
+			end
 		end
 	elseif ( source == aTab4.BansList ) then
 		if ( guiGridListGetSelectedItem ( aTab4.BansList ) == -1 ) then
@@ -1198,7 +1201,8 @@ function aClientClick ( button )
 end
 
 addEvent ("setVisibilityOfSettingsButton", true)
-function setVisibilityOfSettingsButton (hasResourceSetting)
+function setVisibilityOfSettingsButton (showResourceSetting)
+	hasResourceSetting = showResourceSetting
 	if hasResourceSetting then
 		guiSetVisible(aTab2.ResourceSettings, true)
 	else


### PR DESCRIPTION

This pull request ensures that the GUI settings window is no longer opened if you double-click on a resource name in the resource list and it has no settings. 
In this pull request https://github.com/multitheftauto/mtasa-resources/pull/490 with the change that the settings button should only be displayed if there are settings, I have not considered this.