### PR TITLE
Fix checkpoints alpha

### DIFF
--- a/[editor]/edf/edf.lua
+++ b/[editor]/edf/edf.lua
@@ -952,7 +952,7 @@ function edfGetElementDimension(element)
 end
 
 function edfGetElementAlpha(element)
-	return getElementAlpha(element) or tonumber(getElementData(element, "alpha")) or 255
+	return getElementAlpha(element) or tonumber(getElementData(element, "alpha")) or (getElementType(element) == 'checkpoint' and 128 or 255) -- 128 is checkpoint default max alpha
 end
 
 function edfSetElementDimension(element, dimension)

--- a/[gamemodes]/[race]/race/race_client.lua
+++ b/[gamemodes]/[race]/race/race_client.lua
@@ -1253,8 +1253,13 @@ function createCheckpoint(i)
 	local pos = checkpoint.position
 	local color = checkpoint.color or { 0, 0, 255 }
 	checkpoint.marker = createMarker(pos[1], pos[2], pos[3], checkpoint.type or 'checkpoint', checkpoint.size, color[1], color[2], color[3])
-	if (not checkpoint.type or checkpoint.type == 'checkpoint') and i == #g_Checkpoints then
-		setMarkerIcon(checkpoint.marker, 'finish')
+	
+	if (not checkpoint.type or checkpoint.type == 'checkpoint') then
+		setElementAlpha(checkpoint.marker, 128) -- default checkpoint max alpha
+	
+		if (i == #g_Checkpoints) then
+			setMarkerIcon(checkpoint.marker, 'finish')
+		end
 	end
 	if checkpoint.type == 'ring' and i < #g_Checkpoints then
 		setMarkerTarget(checkpoint.marker, unpack(g_Checkpoints[i+1].position))


### PR DESCRIPTION
PR fixes a problem with the alpha of checkpoint markers in gamemode race and map editor.

The bug was created as a result of: https://github.com/multitheftauto/mtasa-blue/pull/3523