### PR TITLE
admin2: fix bug onPlayerLogin 'p' bind not set

### DIFF
--- a/[admin]/admin2/server/admin_session.lua
+++ b/[admin]/admin2/server/admin_session.lua
@@ -61,7 +61,7 @@ addEventHandler(
                         end
                     end
                 end
-                triggerClientEvent(client or source, EVENT_SESSION, client, tableOut)
+                triggerClientEvent(client or source, EVENT_SESSION, client or source, tableOut)
             end
         end
     end


### PR DESCRIPTION
There's a bug on admin2, start admin2, reconnect and login - 'p' bind isn't set