### PR TITLE
internetradio: add ability to show speaker owner

### DIFF
--- a/[gameplay]/internetradio/config/CRadioConfig.lua
+++ b/[gameplay]/internetradio/config/CRadioConfig.lua
@@ -10,6 +10,7 @@ RADIO_TRACK_COLOR = tocolor(150, 50, 150, 255)
 RADIO_TRACK_BACKGROUND_COLOR = tocolor(0, 0, 0, 255)
 
 RADIO_TOGGLE_KEY = "F3"
+RADIO_SHOW_SPEAKER_OWNER_KEY = "lalt"
 RADIO_SHOW_ON_START = false
 RADIO_COMMANDS = {"sound", "music", "musica", "song", "radio", "speaker"}
 RADIO_SETTINGS_PATH = "settings.json"

--- a/[gameplay]/internetradio/handle_radio/CHandleRadio.lua
+++ b/[gameplay]/internetradio/handle_radio/CHandleRadio.lua
@@ -283,7 +283,7 @@ function isObjectSpeaker(objectElement)
 				local speakerSound = speakerSounds[playerElement]
 				local speakerDummy = speakerData.speakerDummy
 
-				return true, speakerSound, speakerDummy
+				return true, speakerSound, speakerDummy, playerElement
 			end
 		end
 	end

--- a/[gameplay]/internetradio/handle_radio/ShHandleRadio.lua
+++ b/[gameplay]/internetradio/handle_radio/ShHandleRadio.lua
@@ -79,6 +79,12 @@ function getPlayerFromPartialName(partialName)
 	return false
 end
 
+function removeHex(stringToRemoveHexFrom)
+	local removedHex = string.gsub(stringToRemoveHexFrom, "#%x%x%x%x%x%x", "")
+
+	return removedHex
+end
+
 function getOrSetPlayerDelay(playerElement, delayID, delayTime)
 	local validElement = isElement(playerElement)
 

--- a/[gameplay]/internetradio/track_name/CRadioTrackName.lua
+++ b/[gameplay]/internetradio/track_name/CRadioTrackName.lua
@@ -74,11 +74,11 @@ function checkForNearbySpeakers()
 
 	for objectID = 1, #nearbyObjects do
 		local nearbyObject = nearbyObjects[objectID]
-		local _, speakerSound, speakerDummy = isObjectSpeaker(nearbyObject)
+		local _, speakerSound, speakerDummy, speakerOwner = isObjectSpeaker(nearbyObject)
 		local trackName = getSpeakerTrackName(speakerSound)
 
 		if (speakerDummy and trackName) then
-			NEARBY_SPEAKERS[speakerDummy] = trackName
+			NEARBY_SPEAKERS[speakerDummy] = {trackName, speakerOwner}
 		end
 	end
 
@@ -89,7 +89,7 @@ setTimer(checkForNearbySpeakers, 1000, 0)
 function onClientRenderRadioTrackName()
 	local cameraX, cameraY, cameraZ = getCameraMatrix()
 
-	for nearbySpeaker, trackName in pairs(NEARBY_SPEAKERS) do
+	for nearbySpeaker, speakerData in pairs(NEARBY_SPEAKERS) do
 		local speakerX, speakerY, speakerZ = getElementPosition(nearbySpeaker)
 		local distanceToSpeaker = getDistanceBetweenPoints3D(speakerX, speakerY, speakerZ, cameraX, cameraY, cameraZ)
 		local closeToSpeaker = (distanceToSpeaker <= RADIO_MAX_SOUND_DISTANCE)
@@ -99,6 +99,17 @@ function onClientRenderRadioTrackName()
 			local screenX, screenY = getScreenFromWorldPosition(speakerX, speakerY, speakerOffsetZ, 0, false)
 
 			if (screenX and screenY) then
+				local trackName = speakerData[1]
+				local displaySpeakerOwner = getKeyState(RADIO_SHOW_SPEAKER_OWNER_KEY)
+
+				if (displaySpeakerOwner) then
+					local speakerOwner = speakerData[2]
+					local speakerName = getPlayerName(speakerOwner)
+					local speakerPlayerName = removeHex(speakerName)
+
+					trackName = "(Owner: "..speakerPlayerName..") "..trackName
+				end
+
 				local textWidth = dxGetTextWidth(trackName, RADIO_TRACK_SCALE, RADIO_TRACK_FONT, trackNameColorCoded)
 				local textPosX = (screenX - textWidth / 2)
 				local textBackgroundPosX = (textPosX - 5)


### PR DESCRIPTION
As in title, holding LALT (configurable in client-side config -> RADIO_SHOW_SPEAKER_OWNER_KEY) would display speaker owner