### PR TITLE
Fixes #427

### DIFF
--- a/[editor]/edf/properties_client.lua
+++ b/[editor]/edf/properties_client.lua
@@ -152,9 +152,6 @@ propertySetters = {
 		end,
 		breakable = function(element, breakable)
 			return setObjectBreakable(element, breakable == "true")
-		end,
-		collisions = function(element, state)
-			return setElementCollisionsEnabled(element, state == "true")
 		end
 	},
 	ped = {


### PR DESCRIPTION
This commit removes the property setter for object collisions as actually changing the collisions for objects in the editor mode makes them no longer selectable without High Sensivity Mode (e). processLineOfSight doesn't pickup collisionless objects.

This shouldn't really affect anything?