### PR TITLE
editor: Fix UI appearing during map testing when "collision patches" enabled

### DIFF
--- a/[editor]/editor_gui/client/test.lua
+++ b/[editor]/editor_gui/client/test.lua
@@ -142,7 +142,7 @@ function disableColPatchInTesting()
 	
 	-- Disable
 	guiCheckBoxSetSelected(dialog.enableColPatch.GUI.checkbox, false)
-	confirmSettings()
+	doActions()
 end
 
 function enableColPatchAfterTesting()


### PR DESCRIPTION
Fixes #532, Currently the map editor shows the UI when collision patches are enabled during map testing, this caused by https://github.com/multitheftauto/mtasa-resources/blob/80d98fdc7daf7748756a7726b3261362ad8bdc9c/%5Beditor%5D/editor_gui/client/options_gui.lua#L127-L136
