### PR TITLE
[editor] Fix editor_gui test panel

### DIFF
--- a/[editor]/editor_gui/client/test.lua
+++ b/[editor]/editor_gui/client/test.lua
@@ -251,3 +251,11 @@ end
 function noDamageInBasicTest()
 	cancelEvent()
 end
+
+addEventHandler ( "saveloadtest_return", root,
+	function ( command )
+		if command == "new" or command == "open" then
+			lastTestGamemode = nil
+		end
+	end
+)

--- a/[editor]/editor_gui/client/test.lua
+++ b/[editor]/editor_gui/client/test.lua
@@ -32,7 +32,7 @@ function quickTest()
 	if tutorialVars.blockQuickTest then return end
 	if lastTestGamemode == "<None>" then lastTestGamemode = false end
 	editor_main.dropElement()
-	triggerServerEvent ( "testResource",localPlayer, text )
+	triggerServerEvent ( "testResource",localPlayer, lastTestGamemode )
 	unbindControl ( "toggle_test", "down", quickTest )
 	if tutorialVars.test then tutorialNext() end
 end

--- a/[editor]/editor_main/server/saveloadtest_server.lua
+++ b/[editor]/editor_main/server/saveloadtest_server.lua
@@ -753,7 +753,11 @@ function beginTest(client,gamemodeName)
 	resetMapInfo()
 	setupMapSettings()
 	disablePickups(false)
-	gamemodeName = gamemodeName or lastTestGamemodeName
+
+	if gamemodeName == nil then
+		gamemodeName = lastTestGamemodeName
+	end
+
 	if ( gamemodeName ) then
 		lastTestGamemodeName = gamemodeName
 		set ( "*freeroam.spawnmapondeath", "false" )
@@ -785,6 +789,9 @@ function beginTest(client,gamemodeName)
 		end
 		g_in_test = "gamemode"
 	else
+		if gamemodeName == false then
+			lastTestGamemodeName = gamemodeName
+		end
 		if getResourceState(freeroamRes) ~= "running" and not startResource ( freeroamRes, true ) then
 			restoreSettings()
 			triggerClientEvent ( root, "saveloadtest_return", client, "test", false, false,

--- a/[editor]/editor_main/server/saveloadtest_server.lua
+++ b/[editor]/editor_main/server/saveloadtest_server.lua
@@ -120,6 +120,8 @@ addEventHandler("newResource", root,
 
 		actionList = {}
 		currentActionIndex = 0
+
+		lastTestGamemodeName = nil
 	end
 )
 
@@ -153,6 +155,8 @@ function handleOpenResource()
 
 		actionList = {}
 		currentActionIndex = 0
+
+		lastTestGamemodeName = nil
 
 		triggerEvent("onMapOpened", mapContainer, openingResource)
 		flattenTreeRuns = 0


### PR DESCRIPTION
Fixes: After testing a certain map with a gamemode (ex. race), you are unable to test the same map with the `<None>` option anymore.
Retains last testing gamemode upon reconnecting.