### PR TITLE
[editor] Fix duplicate map meta entries resulting in editor suspending.

### DIFF
--- a/[editor]/editor_main/server/resourcehooks.lua
+++ b/[editor]/editor_main/server/resourcehooks.lua
@@ -101,7 +101,9 @@ function getResourceFiles ( resource, fileType )
 		local file = xmlNodeGetAttribute ( node, "src" )
 		local otherAttributes = xmlNodeGetAttributes ( node )
 		otherAttributes.src = nil
-		if not fileAttributes[file] then
+		if fileAttributes[file] then
+			outputDebugString("getResourceFiles: Found duplicate meta entry in '".. resource .."' (".. fileType .. " - ".. file .. ")")
+		else
 			fileAttributes[file] = otherAttributes
 			table.insert ( files, file )
 		end
@@ -121,7 +123,9 @@ function copyResourceFiles ( fromResource, targetResource )
 		if paths then
 			for j,filePath in ipairs(paths) do
 				local copyPath, copyTarget = ":" .. getResourceName(fromResource) .. "/" .. filePath, ":" .. getResourceName(targetResource) .. "/" .. filePath
-				if not fileExists(copyTarget) then
+				if fileExists(copyTarget) then
+					outputDebugString("copyResourceFiles: File '".. copyTarget .."' has duplicate meta entries, cannot overwrite.")
+				else
 					fileCopy ( copyPath, copyTarget, false )
 					local data = attr[filePath]
 					data.src = filePath

--- a/[editor]/editor_main/server/resourcehooks.lua
+++ b/[editor]/editor_main/server/resourcehooks.lua
@@ -101,8 +101,10 @@ function getResourceFiles ( resource, fileType )
 		local file = xmlNodeGetAttribute ( node, "src" )
 		local otherAttributes = xmlNodeGetAttributes ( node )
 		otherAttributes.src = nil
-		fileAttributes[file] = otherAttributes
-		table.insert ( files, file )
+		if not fileAttributes[file] then
+			fileAttributes[file] = otherAttributes
+			table.insert ( files, file )
+		end
 		i = i + 1
 	end
 	xmlUnloadFile ( meta )
@@ -118,10 +120,13 @@ function copyResourceFiles ( fromResource, targetResource )
 		local paths, attr = getResourceFiles(fromResource, fileType)
 		if paths then
 			for j,filePath in ipairs(paths) do
-				fileCopy ( ":" .. getResourceName(fromResource) .. "/" .. filePath, ":" .. getResourceName(targetResource) .. "/" .. filePath, false )
-				local data = attr[filePath]
-				data.src = filePath
-				table.insert ( targetPaths[fileType], data )
+				local copyPath, copyTarget = ":" .. getResourceName(fromResource) .. "/" .. filePath, ":" .. getResourceName(targetResource) .. "/" .. filePath
+				if not fileExists(copyTarget) then
+					fileCopy ( copyPath, copyTarget, false )
+					local data = attr[filePath]
+					data.src = filePath
+					table.insert ( targetPaths[fileType], data )
+				end
 			end
 		else
 			outputDebugString("copyResourceFiles: getResourceFiles returned "..tostring(paths).." and "..tostring(attr).." for "..tostring(fromResource).." and "..tostring(fileType))


### PR DESCRIPTION
Fixes #538

![Screenshot_24](https://github.com/user-attachments/assets/1ce1dbd9-9cae-49b5-83c5-ff7518202747)

This does not check for multiple files with different attributes (ex. scripts type that use both `client` and `server` instead of `shared`).