### PR TITLE
[editor] Fix GUI not initializing on join after test map ending

### DIFF
--- a/[editor]/editor_main/client/main.lua
+++ b/[editor]/editor_main/client/main.lua
@@ -146,8 +146,6 @@ function startWhenLoaded()
 	if getElementData(resourceRoot,"g_in_test") then
 		setElementData ( localPlayer, "waitingToStart", true, false )
 		return
-	else
-		setElementData ( localPlayer, "waitingToStart", nil, false )
 	end
 	if isInterfaceLoaded() then
 		removeEventHandler("onClientResourceStart", root, startWhenLoaded)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1f56a47e-13fc-4b53-8812-538d00b2d50b)

This elementData removal is being handled by `editor_gui` in `resumeGUI()`:
https://github.com/multitheftauto/mtasa-resources/blob/83e2c79cbd959aa54c55d4220a5b4d38747e8353/%5Beditor%5D/editor_gui/client/test.lua#L91-L97

I don't see any other reason for this to be in `editor_main`, unless I'm missing something..?