### PR TITLE
internetradio: Fix playSound3D and track name showing in other dimensions

### DIFF
--- a/[gameplay]/internetradio/handle_radio/CHandleRadio.lua
+++ b/[gameplay]/internetradio/handle_radio/CHandleRadio.lua
@@ -102,7 +102,7 @@ function toggleSpeakerSounds(playerElement, toggleOn)
 		speakerSounds[playerElement] = speakerNewSound
 
 		setElementInterior(speakerNewSound, speakerInterior)
-		setElementInterior(speakerNewSound, speakerDimension)
+		setElementDimension(speakerNewSound, speakerDimension)
 
 		setSoundPaused(speakerNewSound, speakerPaused)
 		setSoundMaxDistance(speakerNewSound, speakerSoundMaxDistance)
@@ -193,6 +193,8 @@ function setPlayerSpeakerData(playerElement, speakerData)
 
 	local speakerBox = speakerData.speakerBox
 	local speakerDummy = createObject(1337, 0, 0, 3)
+	local speakerBoxDimension = getElementDimension(speakerBox)
+	setElementDimension(speakerDummy, speakerBoxDimension)
 
 	speakerData.speakerDummy = speakerDummy
 	playerSpeakers[playerElement] = speakerData


### PR DESCRIPTION
Fix bugs caused by playing the sound in dimensions other than 0
- The sound created by playSound3D didn't move to the player's dimension, so the player could not hear it
- Track name wasn't visible in other dimensions