### PR TITLE
[editor] Fix debugscript warnings when testing an unopened map

### DIFF
--- a/[editor]/editor_main/server/mapsettingssync.lua
+++ b/[editor]/editor_main/server/mapsettingssync.lua
@@ -191,6 +191,9 @@ function passDefaultMapSettings()
 end
 
 function passNewMapSettings()
+
+	if type(loadedMap) ~= "string" then return false end
+	
 	local mapResource = getResourceFromName(loadedMap)
 
 	--General settings

--- a/[editor]/editor_main/server/mapsettingssync.lua
+++ b/[editor]/editor_main/server/mapsettingssync.lua
@@ -192,9 +192,16 @@ end
 
 function passNewMapSettings()
 
-	if type(loadedMap) ~= "string" then return false end
+	if type(loadedMap) ~= "string" then 
+		return false
+	end
 	
 	local mapResource = getResourceFromName(loadedMap)
+	
+	if not mapResource then 
+		loadedMap = false 
+		return false 
+	end
 
 	--General settings
 	local settings = getSettings(mapResource)


### PR DESCRIPTION
Reproducing the bug:
`1. Start editor`
`2. Test`

Second check is added to avoid the other errors caused by `copyResourceFiles()`.
Set as draft after finding out `currentMapSettings` causes `edf` script errors.