### PR TITLE
Race edf: Fix automatic nextid assignment breaking

### DIFF
--- a/[gamemodes]/[race]/race/edf/edf.lua
+++ b/[gamemodes]/[race]/race/edf/edf.lua
@@ -29,15 +29,17 @@ addEventHandler ( "onMapOpened", root,
 addEventHandler ( "onElementCreate", root,
 	function()
 		if getElementType(source) == "checkpoint" then
-			--Find the first element without a nextid
+			--Find the first non-destroyed element without a nextid
 			for i,checkpoint in ipairs(getElementsByType"checkpoint") do
-				if checkpoint ~= source and not exports.edf:edfGetElementProperty ( checkpoint, "nextid" ) then
+				if checkpoint ~= source and not exports.edf:edfGetElementProperty ( checkpoint, "nextid" ) and getElementDimension(getRepresentation(checkpoint,"marker")) == exports.editor_main:getWorkingDimension() then
 					exports.edf:edfSetElementProperty ( checkpoint, "nextid", source )
 					break
 				end
 			end
 			local marker = getRepresentation(source,"marker")
 			setMarkerIcon ( marker, "finish" )
+			-- Clear new clone checkpoint's nextid as a checkpoint is to be pointed to by only one other
+			exports.edf:edfSetElementProperty( source, "nextid", nil)
 		end
 	end
 )


### PR DESCRIPTION
Duplicating a checkpoint with a nextid set would point that clone to the same checkpoint which resulted in multiple checkpoints pointing to another resulting in stray checkpoints.

When deleted checkpoints are in play and a new checkpoint was created, it would be automatically pointed to by said deleted checkpoint instead of an existing one, resulting in stray checkpoint sequences.

Fixed both. New checkpoints are now placed after the existing sequence as expected.