### PR TITLE
freeroam: bugfix on fr_client.lua onExitVehicle function

### DIFF
--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -2123,7 +2123,9 @@ function onExitVehicle(vehicle,seat)
 		hideControls(wndMain, 'repair', 'flip', 'upgrades', 'color', 'paintjob', 'lightson', 'lightsoff')
 		closeWindow(wndUpgrades)
 		closeWindow(wndColor)
-	elseif vehicle and seat == 0 then
+	end
+		
+	if vehicle and seat == 0 then
 		if source and g_PlayerData[source] then
 			setVehicleGhost(vehicle,hasDriverGhost(vehicle))
 		end


### PR DESCRIPTION
There is no point of putting 'elseif' on that spesific place, it causes problems with anti-ramming system since it actually blocks the setVehicleGhost(vehicle,hasDriverGhost(vehicle)), it should be 'end if' instead. That way when driver of the vehicle exits the vehicle, ghostmode vehicle can be back to it's normal state.

VIDEO of the bug: https://youtu.be/ZRFNxSeI1Eo