### PR TITLE
Fix #535: Map key bind interferes with race editor help

### DIFF
--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -2243,8 +2243,18 @@ addEventHandler('onClientResourceStart', resourceRoot,
 		createWindow(wndMain)
 		hideAllWindows()
 		bindKey('f1', 'down', toggleFRWindow)
+		bindKey('f2', 'down', toggleMap)
 		guiCheckBoxSetSelected(getControl(wndMain, 'jetpack'), isPedWearingJetpack(localPlayer))
 		guiCheckBoxSetSelected(getControl(wndMain, 'falloff'), canPedBeKnockedOffBike(localPlayer))
+	end
+)
+
+addEventHandler('onClientResourceStart', root,
+	function(startedResource)
+		local editorResource, raceResource = getResourceFromName('editor'), getResourceFromName('race')
+		if (editorResource and raceResource and startedResource == raceResource) then
+			unbindKey('f2', 'down', toggleMap)
+		end
 	end
 )
 
@@ -2267,7 +2277,6 @@ function toggleMap()
 		showCursor(true)
 	end
 end
-bindKey("f2", "down", toggleMap)
 
 function toggleFRWindow()
 	if isWindowOpen(wndMain) then
@@ -2352,6 +2361,15 @@ addEventHandler('onClientResourceStop', resourceRoot,
 	function()
 		showCursor(false)
 		setPedAnimation(localPlayer, false)
+	end
+)
+
+addEventHandler('onClientResourceStop', root,
+	function(stoppingResource)
+		local editorResource, raceResource = getResourceFromName('editor'), getResourceFromName('race')
+		if (editorResource and raceResource and stoppingResource == raceResource) then
+			bindKey('f2', 'down', toggleMap)
+		end
 	end
 )
 


### PR DESCRIPTION
Added onClientResourceStart and onClientResourceStop event handlers to listen on the root element.

When both the editor resource, and the race resource are active, it unbinds toggleMap from F2

When the editor resource is active, and you stop the race resource, it binds toggleMap back to F2.

Since the help menu in Race is only active when the editor is active, this should really be the only time it should either bind or unbind the toggleMap.