### PR TITLE
voice_local: fixes and improvements

### DIFF
--- a/[gameplay]/voice_local/client.lua
+++ b/[gameplay]/voice_local/client.lua
@@ -3,6 +3,7 @@ addEvent("voice_local:onClientPlayerVoiceStart", true)
 addEvent("voice_local:onClientPlayerVoiceStop", true)
 addEvent("voice_local:updateSettings", true)
 
+-- Only starts handling player voices after receiving the settings from the server
 local initialWaiting = true
 
 local streamedPlayers = {}
@@ -78,14 +79,14 @@ addEventHandler("onClientResourceStart", resourceRoot, function()
             streamedPlayers[player] = false
         end
     end
-    triggerServerEvent("voice_local:setPlayerBroadcast", resourceRoot, streamedPlayers)
+    triggerServerEvent("voice_local:setPlayerBroadcast", localPlayer, streamedPlayers)
 end, false)
 
 -- Handle remote/other player quit
 addEventHandler("onClientPlayerQuit", root, function()
     if streamedPlayers[source] ~= nil then
         streamedPlayers[source] = nil
-        triggerServerEvent("voice_local:removeFromPlayerBroadcast", resourceRoot, source)
+        triggerServerEvent("voice_local:removeFromPlayerBroadcast", localPlayer, source)
     end
 end)
 
@@ -100,7 +101,7 @@ addEventHandler("onClientElementStreamIn", root, function()
     if streamedPlayers[source] == nil then
         setSoundVolume(source, 0)
         streamedPlayers[source] = false
-        triggerServerEvent("voice_local:addToPlayerBroadcast", resourceRoot, source)
+        triggerServerEvent("voice_local:addToPlayerBroadcast", localPlayer, source)
     end
 end)
 addEventHandler("onClientElementStreamOut", root, function()
@@ -110,12 +111,12 @@ addEventHandler("onClientElementStreamOut", root, function()
     if streamedPlayers[source] ~= nil then
         setSoundVolume(source, 0)
         streamedPlayers[source] = nil
-        triggerServerEvent("voice_local:removeFromPlayerBroadcast", resourceRoot, source)
+        triggerServerEvent("voice_local:removeFromPlayerBroadcast", localPlayer, source)
     end
 end)
 
 -- Update player talking status (for displaying)
-addEventHandler("voice_local:onClientPlayerVoiceStart", resourceRoot, function(player)
+addEventHandler("voice_local:onClientPlayerVoiceStart", root, function(player)
     if not (isElement(player) and getElementType(player) == "player") then return end
 
     if player == localPlayer then
@@ -124,7 +125,7 @@ addEventHandler("voice_local:onClientPlayerVoiceStart", resourceRoot, function(p
         streamedPlayers[player] = true
     end
 end)
-addEventHandler("voice_local:onClientPlayerVoiceStop", resourceRoot, function(player)
+addEventHandler("voice_local:onClientPlayerVoiceStop", root, function(player)
     if not (isElement(player) and getElementType(player) == "player") then return end
 
     if player == localPlayer then
@@ -134,7 +135,8 @@ addEventHandler("voice_local:onClientPlayerVoiceStop", resourceRoot, function(pl
     end
 end)
 
-addEventHandler("voice_local:updateSettings", resourceRoot, function(settingsFromServer)
+-- Load the settings received from the server
+addEventHandler("voice_local:updateSettings", localPlayer, function(settingsFromServer)
     settings = settingsFromServer
 
     if initialWaiting then

--- a/[gameplay]/voice_local/client.lua
+++ b/[gameplay]/voice_local/client.lua
@@ -7,7 +7,6 @@ local MAX_VOICE_DISTANCE = 25
 
 local streamedPlayers = {}
 
-local mathexp = math.exp
 local sx, sy = guiGetScreenSize()
 
 local nx, ny = sx / 1920, sy / 1080
@@ -17,42 +16,35 @@ local halfWidth = width / 2
 local halfHeight = height / 2
 local icon = dxCreateTexture("icon.png", "dxt5", true, "clamp")
 
+local localPlayerTalking = false
+
 local function preRender()
-    local x, y, z = getCameraMatrix()
+    local cx, cy, cz = getCameraMatrix()
     for player, talking in pairs(streamedPlayers) do
-        if player and isElement(player) and getElementType(player) == "player" then
-            local x1, y1, z1 = getElementPosition(player)
-            local fDistance = getDistanceBetweenPoints3D(x, y, z, x1, y1, z1)
+        local px, py, pz = getElementPosition(player)
+        local distanceToPlayer = getDistanceBetweenPoints3D(cx, cy, cz, px, py, pz)
 
-            local fVolume
-            if (fDistance <= 0) then
-                fVolume = 100
-            elseif (fDistance >= MAX_VOICE_DISTANCE) then
-                fVolume = 0.0
-            else
-                fVolume = (mathexp((fDistance) * (3.0 / fDistance)) * 100) * 3
-            end
-            setSoundVolume(player, fVolume / 100)
+        local playerVolume
+        if (distanceToPlayer <= 0) then
+            playerVolume = 1.0
+        elseif (distanceToPlayer >= MAX_VOICE_DISTANCE) then
+            playerVolume = 0.0
+        else
+            playerVolume = (1.0 - (distanceToPlayer / MAX_VOICE_DISTANCE)^2)
+        end
+        setSoundVolume(player, playerVolume)
 
-            local lineOfSightClear = isLineOfSightClear(x, y, z, x1, y1, z1, false, false, false, false, true, true, true, localPlayer)
-            if lineOfSightClear then
-                setSoundEffectEnabled(player, "compressor", false)
-
-                if talking and settings.playersTalkingIcon.value then
-                    local boneX, boneY, boneZ = getPedBonePosition(player, 8)
-                    local screenX, screenY = getScreenFromWorldPosition(boneX, boneY, boneZ + 0.5)
-                    if screenX and screenY and fDistance < MAX_VOICE_DISTANCE then
-                        fDistance = 1 / fDistance
-                        dxDrawImage(screenX - halfWidth * fDistance, screenY - halfHeight * fDistance, width * fDistance, height * fDistance, icon, 0, 0, 0, -1, false)
-                    end
-                end
-            else
-                setSoundEffectEnabled(player, "compressor", true)
+        if talking and settings.playersTalkingIcon.value and isLineOfSightClear(cx, cy, cz, px, py, pz, false, false, false, false, true, true, true, localPlayer) then
+            local boneX, boneY, boneZ = getPedBonePosition(player, 8)
+            local screenX, screenY = getScreenFromWorldPosition(boneX, boneY, boneZ + 0.5)
+            if screenX and screenY and fDistance < MAX_VOICE_DISTANCE then
+                fDistance = 1 / fDistance
+                dxDrawImage(screenX - halfWidth * fDistance, screenY - halfHeight * fDistance, width * fDistance, height * fDistance, icon, 0, 0, 0, -1, false)
             end
         end
     end
     if settings.ownTalkingTextEnabled.value then
-        if streamedPlayers[localPlayer] == true then
+        if localPlayerTalking then
             dxDrawText("Voice: ON", 5, sy - 20, sx, sy, 0xff00ff00, 1, "default-bold", "left", "center")
         else
             dxDrawText("Voice: OFF", 5, sy - 20, sx, sy, 0x44ffffff, 1, "default-bold", "left", "center")
@@ -64,7 +56,8 @@ addEventHandler("onClientPreRender", root, preRender)
 local function onStart()
     local x, y, z = getElementPosition(localPlayer)
     for _, player in ipairs(getElementsWithinRange(x, y, z, 250, "player")) do
-        if streamedPlayers[player] == nil then
+        if player ~= localPlayer and streamedPlayers[player] == nil then
+            setSoundVolume(source, 0)
             streamedPlayers[player] = false
         end
     end
@@ -72,9 +65,11 @@ local function onStart()
 end
 addEventHandler("onClientResourceStart", resourceRoot, onStart, false)
 
+-- Handle remote/other player join
 local function playerJoin()
     if getElementType(source) == "player" then
         if streamedPlayers[source] == nil then
+            setSoundVolume(source, 0)
             streamedPlayers[source] = false
             triggerServerEvent("voice:addToPlayerBroadcast", resourceRoot, source)
         end
@@ -82,10 +77,10 @@ local function playerJoin()
 end
 addEventHandler("onClientPlayerJoin", root, playerJoin)
 
+-- Handle remote/other player quit
 local function playerQuit()
     if streamedPlayers[source] ~= nil then
         streamedPlayers[source] = nil
-        setSoundVolume(source, 0)
         triggerServerEvent("voice:removePlayerBroadcast", resourceRoot, source)
     end
 end
@@ -93,43 +88,37 @@ addEventHandler("onClientPlayerQuit", root, playerQuit)
 
 -- Code considers this event's problem @ "Note" box: https://wiki.multitheftauto.com/wiki/OnClientElementStreamIn
 -- It should be modified if said behavior ever changes
+-- Stream in event
 local function streamIn()
     if (isElement(source) and getElementType(source) == "player" and isPedDead(source) == false) then
         if streamedPlayers[source] == nil then
+            setSoundVolume(source, 0)
             streamedPlayers[source] = false
             triggerServerEvent("voice:addToPlayerBroadcast", resourceRoot, source)
+            print("streaming in", getPlayerName(source))
         end
     end
 end
 addEventHandler("onClientElementStreamIn", root, streamIn)
 
--- To ensure table integrity, stream out & local player death into 2 separate, safer events
--- See the "Note" box at https://wiki.multitheftauto.com/wiki/OnClientElementStreamIn for reason why
 -- Stream out event
 local function streamOut()
     if (source ~= localPlayer and isElement(source) and getElementType(source) == "player") then
         if streamedPlayers[source] ~= nil then
-            streamedPlayers[source] = nil
             setSoundVolume(source, 0)
+            streamedPlayers[source] = nil
             triggerServerEvent("voice:removePlayerBroadcast", resourceRoot, source)
+            print("streaming out", getPlayerName(source))
         end
     end
 end
 addEventHandler("onClientElementStreamOut", root, streamOut)
 
--- Local player death event
-local function onWasted()
-    if streamedPlayers[localPlayer] ~= nil then
-        streamedPlayers[localPlayer] = nil
-        setSoundVolume(localPlayer, 0)
-        triggerServerEvent("voice:removePlayerBroadcast", resourceRoot, localPlayer)
-    end
-end
-addEventHandler("onClientPlayerWasted", localPlayer, onWasted)
-
 local function voiceStart(source)
     if (isElement(source) and getElementType(source) == "player") then
-        if streamedPlayers[source] ~= nil then
+        if source == localPlayer then
+            localPlayerTalking = true
+        elseif streamedPlayers[source] ~= nil then
             streamedPlayers[source] = true
         end
     end
@@ -138,7 +127,9 @@ addEventHandler("voice_cl:onClientPlayerVoiceStart", resourceRoot, voiceStart)
 
 local function voiceStop(source)
     if (isElement(source) and getElementType(source) == "player") then
-        if streamedPlayers[source] ~= nil then
+        if source == localPlayer then
+            localPlayerTalking = false
+        elseif streamedPlayers[source] ~= nil then
             streamedPlayers[source] = false
         end
     end

--- a/[gameplay]/voice_local/client.lua
+++ b/[gameplay]/voice_local/client.lua
@@ -3,8 +3,6 @@ addEvent("voice_cl:onClientPlayerVoiceStart", true)
 addEvent("voice_cl:onClientPlayerVoiceStop", true)
 addEvent("voice_local:updateSettings", true)
 
-local MAX_VOICE_DISTANCE = 25
-
 local streamedPlayers = {}
 
 local sx, sy = guiGetScreenSize()
@@ -23,21 +21,21 @@ addEventHandler("onClientPreRender", root, function()
     for player, talking in pairs(streamedPlayers) do
         local px, py, pz = getElementPosition(player)
         local distanceToPlayer = getDistanceBetweenPoints3D(cx, cy, cz, px, py, pz)
-
+        local maxDistance = settings.maxVoiceDistance.value
         local playerVolume
         if (distanceToPlayer <= 0) then
             playerVolume = 1.0
-        elseif (distanceToPlayer >= MAX_VOICE_DISTANCE) then
+        elseif (distanceToPlayer >= maxDistance) then
             playerVolume = 0.0
         else
-            playerVolume = (1.0 - (distanceToPlayer / MAX_VOICE_DISTANCE)^2)
+            playerVolume = (1.0 - (distanceToPlayer / maxDistance)^2)
         end
         setSoundVolume(player, playerVolume)
 
         if talking and settings.playersTalkingIcon.value and isLineOfSightClear(cx, cy, cz, px, py, pz, false, false, false, false, true, true, true, localPlayer) then
             local boneX, boneY, boneZ = getPedBonePosition(player, 8)
             local screenX, screenY = getScreenFromWorldPosition(boneX, boneY, boneZ + 0.5)
-            if screenX and screenY and fDistance < MAX_VOICE_DISTANCE then
+            if screenX and screenY and fDistance < maxDistance then
                 fDistance = 1 / fDistance
                 dxDrawImage(screenX - halfWidth * fDistance, screenY - halfHeight * fDistance, width * fDistance, height * fDistance, icon, 0, 0, 0, -1, false)
             end

--- a/[gameplay]/voice_local/client.lua
+++ b/[gameplay]/voice_local/client.lua
@@ -1,96 +1,103 @@
-local fMinDistance = 0
-local fMaxDistance = 25
-local mathexp = math.exp
+-- Remote events:
+addEvent("voice_cl:onClientPlayerVoiceStart", true)
+addEvent("voice_cl:onClientPlayerVoiceStop", true)
+addEvent("voice_local:updateSettings", true)
+
+local MAX_VOICE_DISTANCE = 25
+
 local streamedPlayers = {}
-local fDistDiff = fMinDistance - fMaxDistance
 
+local mathexp = math.exp
 local sx, sy = guiGetScreenSize()
-local nx, ny = sx / 1920, sy / 1080
 
+local nx, ny = sx / 1920, sy / 1080
 local width = 108 * nx
 local height = 180 * ny
-local xOffset = 75 * nx
-local yOffset = 50 * ny
 local halfWidth = width / 2
 local halfHeight = height / 2
-
 local icon = dxCreateTexture("icon.png", "dxt5", true, "clamp")
 
-function preRender()
-    local x, y, z, lx, ly, lz = getCameraMatrix()
-
+local function preRender()
+    local x, y, z = getCameraMatrix()
     for player, talking in pairs(streamedPlayers) do
         if player and isElement(player) and getElementType(player) == "player" then
             local x1, y1, z1 = getElementPosition(player)
             local fDistance = getDistanceBetweenPoints3D(x, y, z, x1, y1, z1)
 
             local fVolume
-            if (fDistance <= fMinDistance) then
+            if (fDistance <= 0) then
                 fVolume = 100
-            elseif (fDistance >= fMaxDistance) then
+            elseif (fDistance >= MAX_VOICE_DISTANCE) then
                 fVolume = 0.0
             else
-                fVolume = mathexp(-(fDistance - fMinDistance) * (5.0 / fDistDiff)) * 100
+                fVolume = (mathexp((fDistance) * (3.0 / fDistance)) * 100) * 3
             end
+            setSoundVolume(player, fVolume / 100)
 
-            if isLineOfSightClear(x, y, z, x1, y1, z1, false, false, false, false, true, true, true, localPlayer) then
-                setSoundVolume(player, fVolume)
+            local lineOfSightClear = isLineOfSightClear(x, y, z, x1, y1, z1, false, false, false, false, true, true, true, localPlayer)
+            if lineOfSightClear then
                 setSoundEffectEnabled(player, "compressor", false)
+
+                if talking and settings.playersTalkingIcon.value then
+                    local boneX, boneY, boneZ = getPedBonePosition(player, 8)
+                    local screenX, screenY = getScreenFromWorldPosition(boneX, boneY, boneZ + 0.5)
+                    if screenX and screenY and fDistance < MAX_VOICE_DISTANCE then
+                        fDistance = 1 / fDistance
+                        dxDrawImage(screenX - halfWidth * fDistance, screenY - halfHeight * fDistance, width * fDistance, height * fDistance, icon, 0, 0, 0, -1, false)
+                    end
+                end
             else
-                setSoundVolume(player, fVolume * 2)
                 setSoundEffectEnabled(player, "compressor", true)
             end
-
-            if talking and isLineOfSightClear(x, y, z, x1, y1, z1, false, false, false, false, true, true, true, localPlayer) then
-                local boneX, boneY, boneZ = getPedBonePosition(player, 8)
-                local screenX, screenY = getScreenFromWorldPosition(boneX, boneY, boneZ + 0.5)
-                if screenX and screenY and fDistance < fMaxDistance then
-                    fDistance = 1 / fDistance
-                    dxDrawImage(screenX - halfWidth * fDistance, screenY - halfHeight * fDistance, width * fDistance, height * fDistance, icon, 0, 0, 0, -1, false)
-                end
-            end
+        end
+    end
+    if settings.ownTalkingTextEnabled.value then
+        if streamedPlayers[localPlayer] == true then
+            dxDrawText("Voice: ON", 5, sy - 20, sx, sy, 0xff00ff00, 1, "default-bold", "left", "center")
+        else
+            dxDrawText("Voice: OFF", 5, sy - 20, sx, sy, 0x44ffffff, 1, "default-bold", "left", "center")
         end
     end
 end
 addEventHandler("onClientPreRender", root, preRender)
 
-function onStart()
+local function onStart()
     local x, y, z = getElementPosition(localPlayer)
     for _, player in ipairs(getElementsWithinRange(x, y, z, 250, "player")) do
         if streamedPlayers[player] == nil then
             streamedPlayers[player] = false
         end
     end
-    triggerServerEvent("voice:setPlayerBroadcast", resourceRoot, localPlayer, streamedPlayers)
+    triggerServerEvent("voice:setPlayerBroadcast", resourceRoot, streamedPlayers)
 end
 addEventHandler("onClientResourceStart", resourceRoot, onStart, false)
 
-function playerJoin()
+local function playerJoin()
     if getElementType(source) == "player" then
         if streamedPlayers[source] == nil then
             streamedPlayers[source] = false
-            triggerServerEvent("voice:addToPlayerBroadcast", resourceRoot, localPlayer, source)
+            triggerServerEvent("voice:addToPlayerBroadcast", resourceRoot, source)
         end
     end
 end
 addEventHandler("onClientPlayerJoin", root, playerJoin)
 
-function playerQuit()
+local function playerQuit()
     if streamedPlayers[source] ~= nil then
         streamedPlayers[source] = nil
         setSoundVolume(source, 0)
-        triggerServerEvent("voice:removePlayerBroadcast", resourceRoot, localPlayer, source)
+        triggerServerEvent("voice:removePlayerBroadcast", resourceRoot, source)
     end
 end
 addEventHandler("onClientPlayerQuit", root, playerQuit)
 
 -- Code considers this event's problem @ "Note" box: https://wiki.multitheftauto.com/wiki/OnClientElementStreamIn
 -- It should be modified if said behavior ever changes
-function streamIn()
+local function streamIn()
     if (isElement(source) and getElementType(source) == "player" and isPedDead(source) == false) then
         if streamedPlayers[source] == nil then
             streamedPlayers[source] = false
-            triggerServerEvent("voice:addToPlayerBroadcast", resourceRoot, localPlayer, source)
+            triggerServerEvent("voice:addToPlayerBroadcast", resourceRoot, source)
         end
     end
 end
@@ -99,57 +106,45 @@ addEventHandler("onClientElementStreamIn", root, streamIn)
 -- To ensure table integrity, stream out & local player death into 2 separate, safer events
 -- See the "Note" box at https://wiki.multitheftauto.com/wiki/OnClientElementStreamIn for reason why
 -- Stream out event
-function streamOut()
+local function streamOut()
     if (source ~= localPlayer and isElement(source) and getElementType(source) == "player") then
         if streamedPlayers[source] ~= nil then
             streamedPlayers[source] = nil
             setSoundVolume(source, 0)
-            triggerServerEvent("voice:removePlayerBroadcast", resourceRoot, localPlayer, source)
+            triggerServerEvent("voice:removePlayerBroadcast", resourceRoot, source)
         end
     end
 end
 addEventHandler("onClientElementStreamOut", root, streamOut)
 
 -- Local player death event
-function onWasted()
+local function onWasted()
     if streamedPlayers[localPlayer] ~= nil then
         streamedPlayers[localPlayer] = nil
         setSoundVolume(localPlayer, 0)
-        triggerServerEvent("voice:removePlayerBroadcast", resourceRoot, localPlayer, localPlayer)
+        triggerServerEvent("voice:removePlayerBroadcast", resourceRoot, localPlayer)
     end
 end
 addEventHandler("onClientPlayerWasted", localPlayer, onWasted)
 
-function resourceStop()
-    triggerServerEvent("voice:removePlayerBroadcasts", resourceRoot, localPlayer, streamedPlayers)
-    streamedPlayers = {}
-end
-addEventHandler("onClientResourceStop", resourceRoot, resourceStop, false)
-
-function voiceStart(source)
+local function voiceStart(source)
     if (isElement(source) and getElementType(source) == "player") then
         if streamedPlayers[source] ~= nil then
             streamedPlayers[source] = true
         end
     end
 end
-addEvent("voice_cl:onClientPlayerVoiceStart", true)
 addEventHandler("voice_cl:onClientPlayerVoiceStart", resourceRoot, voiceStart)
 
-function voiceStop(source)
+local function voiceStop(source)
     if (isElement(source) and getElementType(source) == "player") then
         if streamedPlayers[source] ~= nil then
             streamedPlayers[source] = false
         end
     end
 end
-addEvent("voice_cl:onClientPlayerVoiceStop", true)
 addEventHandler("voice_cl:onClientPlayerVoiceStop", resourceRoot, voiceStop)
 
-function table.empty(a)
-    if type(a) ~= "table" then
-        return false
-    end
-
-    return next(a) == nil
-end
+addEventHandler("voice_local:updateSettings", resourceRoot, function(settingsFromServer)
+    settings = settingsFromServer
+end, false)

--- a/[gameplay]/voice_local/meta.xml
+++ b/[gameplay]/voice_local/meta.xml
@@ -4,8 +4,9 @@
 	<min_mta_version server="1.3.0-0.04570"/>
 
 	<settings>
-		<setting name="*show_talking_icon" value="[true]"/>
 		<setting name="*max_voice_distance" value="[25]"/>
+		<setting name="*voice_sound_boost" value="[6]"/>
+		<setting name="*show_talking_icon" value="[true]"/>
 	</settings>
 
 	<file src="icon.png"/>

--- a/[gameplay]/voice_local/meta.xml
+++ b/[gameplay]/voice_local/meta.xml
@@ -4,9 +4,8 @@
 	<min_mta_version server="1.3.0-0.04570"/>
 
 	<settings>
+		<setting name="*show_talking_icon" value="[true]"/>
 		<setting name="*max_voice_distance" value="[25]"/>
-		<setting name="*display_own_talking_text" value="[true]"/>
-		<setting name="*display_players_talking_icon" value="[false]"/>
 	</settings>
 
 	<file src="icon.png"/>

--- a/[gameplay]/voice_local/meta.xml
+++ b/[gameplay]/voice_local/meta.xml
@@ -4,6 +4,7 @@
 	<min_mta_version server="1.3.0-0.04570"/>
 
 	<settings>
+		<setting name="*max_voice_distance" value="[25]"/>
 		<setting name="*display_own_talking_text" value="[true]"/>
 		<setting name="*display_players_talking_icon" value="[false]"/>
 	</settings>

--- a/[gameplay]/voice_local/meta.xml
+++ b/[gameplay]/voice_local/meta.xml
@@ -1,8 +1,16 @@
 <meta>
-	<info author="MTA contributors (github.com/multitheftauto/mtasa-resources)" version="1.0" name="Local voice chat" description="This resource implements a voice chat where only nearby players can talk to eachother" type="script" />
+	<info author="MTA contributors (github.com/multitheftauto/mtasa-resources)" version="1.1" name="Local voice chat" description="This resource implements a voice chat where only nearby players can talk to eachother" type="script" />
+
+	<min_mta_version server="1.3.0-0.04570"/>
+
+	<settings>
+		<setting name="*display_own_talking_text" value="[true]"/>
+		<setting name="*display_players_talking_icon" value="[false]"/>
+	</settings>
 
 	<file src="icon.png"/>
 
+	<script src="shared.lua" type="shared"/>
 	<script src="client.lua" type="client"/>
 	<script src="server.lua" type="server"/>
 </meta>

--- a/[gameplay]/voice_local/server.lua
+++ b/[gameplay]/voice_local/server.lua
@@ -13,7 +13,7 @@ end
 
 addEventHandler("onPlayerResourceStart", root, function(res)
     if res == resource then
-        triggerClientEvent(source, "voice_local:updateSettings", resourceRoot, settings)
+        triggerClientEvent(source, "voice_local:updateSettings", source, settings)
     end
 end)
 
@@ -45,7 +45,7 @@ local function canPlayerBeWithinOtherPlayerStreamDistance(player, otherPlayer)
     return getDistanceBetweenPoints3D(px, py, pz, opx, opy, opz) <= maxDist
 end
 
-addEventHandler("voice_local:setPlayerBroadcast", resourceRoot, function(players)
+addEventHandler("voice_local:setPlayerBroadcast", root, function(players)
     if not client then return end
     if type(players) ~= "table" then return end
     broadcasts[client] = {client}
@@ -60,9 +60,9 @@ addEventHandler("voice_local:setPlayerBroadcast", resourceRoot, function(players
         end
     end
     setPlayerVoiceBroadcastTo(client, broadcasts[client])
-end, false)
+end)
 
-addEventHandler("voice_local:addToPlayerBroadcast", resourceRoot, function(player)
+addEventHandler("voice_local:addToPlayerBroadcast", root, function(player)
     if not client then return end
     if not (isElement(player) and getElementType(player) == "player") then return end
 
@@ -84,9 +84,9 @@ addEventHandler("voice_local:addToPlayerBroadcast", resourceRoot, function(playe
 
     table.insert(broadcasts[client], player)
     setPlayerVoiceBroadcastTo(client, broadcasts[client])
-end, false)
+end)
 
-addEventHandler("voice_local:removeFromPlayerBroadcast", resourceRoot, function(player)
+addEventHandler("voice_local:removeFromPlayerBroadcast", root, function(player)
     if not client then return end
     if not (isElement(player) and getElementType(player) == "player") then return end
 
@@ -102,7 +102,7 @@ addEventHandler("voice_local:removeFromPlayerBroadcast", resourceRoot, function(
     end
 
     setPlayerVoiceBroadcastTo(client, broadcasts[client])
-end, false)
+end)
 
 addEventHandler("onPlayerVoiceStart", root, function()
     if not broadcasts[source] then
@@ -110,14 +110,14 @@ addEventHandler("onPlayerVoiceStart", root, function()
         cancelEvent()
         return
     end
-    triggerClientEvent(broadcasts[source], "voice_local:onClientPlayerVoiceStart", resourceRoot, source)
+    triggerClientEvent(broadcasts[source], "voice_local:onClientPlayerVoiceStart", source, source)
 end)
 
 addEventHandler("onPlayerVoiceStop", root, function()
     if not broadcasts[source] then
         return
     end
-    triggerClientEvent(broadcasts[source], "voice_local:onClientPlayerVoiceStop", resourceRoot, source)
+    triggerClientEvent(broadcasts[source], "voice_local:onClientPlayerVoiceStop", source, source)
 end)
 
 -- Cancel resource start if voice is not enabled on the server

--- a/[gameplay]/voice_local/server.lua
+++ b/[gameplay]/voice_local/server.lua
@@ -29,19 +29,30 @@ end)
 
 addEventHandler("voice:setPlayerBroadcast", resourceRoot, function(players)
     if not client then return end
-    broadcasts[client] = {}
+    if type(players) ~= "table" then return end
+    broadcasts[client] = {client}
 
     for player, _ in pairs(players) do
-        table.insert(broadcasts[client], player)
+        if player ~= client and isElement(player) and getElementType(player) == "player" then
+            table.insert(broadcasts[client], player)
+        end
     end
-
     setPlayerVoiceBroadcastTo(client, broadcasts[client])
 end, false)
 
 addEventHandler("voice:addToPlayerBroadcast", resourceRoot, function(player)
     if not client then return end
+    if not isElement(player) or getElementType(player) ~= "player" then return end
+
     if not broadcasts[client] then
-        broadcasts[client] = {}
+        broadcasts[client] = {client}
+    end
+
+    -- Prevent duplicates
+    for _, broadcast in ipairs(broadcasts[client]) do
+        if player == broadcast then
+            return
+        end
     end
 
     table.insert(broadcasts[client], player)
@@ -50,13 +61,16 @@ end, false)
 
 addEventHandler("voice:removePlayerBroadcast", resourceRoot, function(player)
     if not client then return end
+    if not isElement(player) or getElementType(player) ~= "player" then return end
+
     if not broadcasts[client] then
         return
     end
 
     for i, broadcast in ipairs(broadcasts[client]) do
-        if player == broadcast then
+        if player~=client and player == broadcast then
             table.remove(broadcasts[client], i)
+            break
         end
     end
 

--- a/[gameplay]/voice_local/server.lua
+++ b/[gameplay]/voice_local/server.lua
@@ -1,7 +1,7 @@
 -- Remote events:
-addEvent("voice:setPlayerBroadcast", true)
-addEvent("voice:addToPlayerBroadcast", true)
-addEvent("voice:removePlayerBroadcast", true)
+addEvent("voice_local:setPlayerBroadcast", true)
+addEvent("voice_local:addToPlayerBroadcast", true)
+addEvent("voice_local:removeFromPlayerBroadcast", true)
 
 local broadcasts = {}
 
@@ -29,41 +29,49 @@ end)
 -- Anti-cheat
 -- Prevents clients from wanting to broadcast their voice to players that are really too far away
 local function canPlayerBeWithinOtherPlayerStreamDistance(player, otherPlayer)
-    local maxDist = getServerConfigSetting("ped_syncer_distance") or 100
-    if not isElement(player) or not isElement(otherPlayer) then
+    local maxDist = tonumber(getServerConfigSetting("ped_syncer_distance")) or 100
+    if (not isElement(player)) or (not isElement(otherPlayer)) then
         return false
     end
     if getElementType(player) ~= "player" or getElementType(otherPlayer) ~= "player" then
         return false
     end
-    if getElementInterior(player) ~= getElementInterior(otherPlayer) or getElementDimension(player) ~= getElementDimension(otherPlayer) then
+    if getElementInterior(player) ~= getElementInterior(otherPlayer)
+    or getElementDimension(player) ~= getElementDimension(otherPlayer) then
         return false
     end
-    return getDistanceBetweenPoints3D(getElementPosition(player), getElementPosition(otherPlayer)) <= maxDist
+    local px, py, pz = getElementPosition(player)
+    local opx, opy, opz = getElementPosition(otherPlayer)
+    return getDistanceBetweenPoints3D(px, py, pz, opx, opy, opz) <= maxDist
 end
 
-addEventHandler("voice:setPlayerBroadcast", resourceRoot, function(players)
+addEventHandler("voice_local:setPlayerBroadcast", resourceRoot, function(players)
     if not client then return end
     if type(players) ~= "table" then return end
     broadcasts[client] = {client}
 
     for player, _ in pairs(players) do
-        if player ~= client and canPlayerBeWithinOtherPlayerStreamDistance(client, player) then
-            table.insert(broadcasts[client], player)
+        if player ~= client then
+            if canPlayerBeWithinOtherPlayerStreamDistance(client, player) then
+                table.insert(broadcasts[client], player)
+            else
+                iprint(eventName, "ignoring", getPlayerName(player))
+            end
         end
     end
     setPlayerVoiceBroadcastTo(client, broadcasts[client])
 end, false)
 
-addEventHandler("voice:addToPlayerBroadcast", resourceRoot, function(player)
+addEventHandler("voice_local:addToPlayerBroadcast", resourceRoot, function(player)
     if not client then return end
-    if not isElement(player) or getElementType(player) ~= "player" then return end
+    if not (isElement(player) and getElementType(player) == "player") then return end
 
     if not broadcasts[client] then
         broadcasts[client] = {client}
     end
 
     if not canPlayerBeWithinOtherPlayerStreamDistance(client, player) then
+        iprint(eventName, "ignoring", getPlayerName(player))
         return
     end
 
@@ -78,9 +86,9 @@ addEventHandler("voice:addToPlayerBroadcast", resourceRoot, function(player)
     setPlayerVoiceBroadcastTo(client, broadcasts[client])
 end, false)
 
-addEventHandler("voice:removePlayerBroadcast", resourceRoot, function(player)
+addEventHandler("voice_local:removeFromPlayerBroadcast", resourceRoot, function(player)
     if not client then return end
-    if not isElement(player) or getElementType(player) ~= "player" then return end
+    if not (isElement(player) and getElementType(player) == "player") then return end
 
     if not broadcasts[client] then
         return
@@ -102,14 +110,14 @@ addEventHandler("onPlayerVoiceStart", root, function()
         cancelEvent()
         return
     end
-    triggerClientEvent(broadcasts[source], "voice_cl:onClientPlayerVoiceStart", resourceRoot, source)
+    triggerClientEvent(broadcasts[source], "voice_local:onClientPlayerVoiceStart", resourceRoot, source)
 end)
 
 addEventHandler("onPlayerVoiceStop", root, function()
     if not broadcasts[source] then
         return
     end
-    triggerClientEvent(broadcasts[source], "voice_cl:onClientPlayerVoiceStop", resourceRoot, source)
+    triggerClientEvent(broadcasts[source], "voice_local:onClientPlayerVoiceStop", resourceRoot, source)
 end)
 
 -- Cancel resource start if voice is not enabled on the server

--- a/[gameplay]/voice_local/server.lua
+++ b/[gameplay]/voice_local/server.lua
@@ -19,7 +19,6 @@ end)
 
 -- Don't let the player talk to anyone as soon as they join
 addEventHandler("onPlayerJoin", root, function()
-    print("not letting", getPlayerName(source), "talk to anyone")
     setPlayerVoiceBroadcastTo(source, {})
 end)
 

--- a/[gameplay]/voice_local/shared.lua
+++ b/[gameplay]/voice_local/shared.lua
@@ -1,4 +1,5 @@
 settings = {
     playersTalkingIcon = {key="display_players_talking_icon", value=nil},
     ownTalkingTextEnabled = {key="display_own_talking_text", value=nil},
+    maxVoiceDistance = {key="max_voice_distance", value=nil},
 }

--- a/[gameplay]/voice_local/shared.lua
+++ b/[gameplay]/voice_local/shared.lua
@@ -1,4 +1,7 @@
 settings = {
     showTalkingIcon = {key="show_talking_icon", value=nil},
     maxVoiceDistance = {key="max_voice_distance", value=nil},
+    voiceSoundBoost = {key="voice_sound_boost", value=nil},
 }
+
+DEBUG_MODE = false

--- a/[gameplay]/voice_local/shared.lua
+++ b/[gameplay]/voice_local/shared.lua
@@ -1,0 +1,4 @@
+settings = {
+    playersTalkingIcon = {key="display_players_talking_icon", value=nil},
+    ownTalkingTextEnabled = {key="display_own_talking_text", value=nil},
+}

--- a/[gameplay]/voice_local/shared.lua
+++ b/[gameplay]/voice_local/shared.lua
@@ -1,5 +1,4 @@
 settings = {
-    playersTalkingIcon = {key="display_players_talking_icon", value=nil},
-    ownTalkingTextEnabled = {key="display_own_talking_text", value=nil},
+    showTalkingIcon = {key="show_talking_icon", value=nil},
     maxVoiceDistance = {key="max_voice_distance", value=nil},
 }


### PR DESCRIPTION
This PR doesn't make any new major enhancements to the resource.

It fixes the scripts in terms of logic and security, and adds two important features:

- new meta.xml settings to configure the following:
- max voice distance - default 25 units
- show talking icon above player head - default true
- voice sound boost multiplier - default 6.0

Testing is recommended on a server with at least 1 other player.
