### PR TITLE
Update fr_server.lua

### DIFF
--- a/[gameplay]/freeroam/fr_server.lua
+++ b/[gameplay]/freeroam/fr_server.lua
@@ -445,27 +445,36 @@ function fadeVehiclePassengersCamera(toggle)
 end
 
 addEventHandler('onPlayerChat', root,
-	function(msg, type)
-		if type == 0 then
-			cancelEvent()
+    function(msg, type)
+        if type == 0 then
+            cancelEvent()
 
-			local blockRepeats = get("*chat/blockRepeatMessages") == "true"
+            local mainChatDelay = tonumber(get("*chat/mainChatDelay")) or 1000
+            local blockRepeatMessages = get("*chat/blockRepeatMessages") == "true"
 
-			if blockRepeats then
-				if lastChatMessage[source] and lastChatMessage[source] == msg then
-					outputChatBox("Stop repeating yourself!", source, 255, 0, 0)
-					return
-				end
-				lastChatMessage[source] = msg
-			end
+            local currentTick = getTickCount()
+            local playerName = getPlayerName(source)
 
-			if isElement(source) then
-				local r, g, b = getPlayerNametagColor(source)
-				outputChatBox(getPlayerName(source) .. ': #FFFFFF' .. stripHex(msg), root, r, g, b, true)
-				outputServerLog("CHAT: " .. getPlayerName(source) .. ": " .. msg)
-			end
-		end
-	end
+            if chatTime[source] and (currentTick - chatTime[source] < mainChatDelay) then
+                outputChatBox("Stop spamming the chat! Wait a moment.", source, 255, 0, 0)
+                return
+            end
+
+            if blockRepeatMessages and lastChatMessage[source] and lastChatMessage[source] == msg then
+                outputChatBox("Stop repeating yourself!", source, 255, 0, 0)
+                return
+            end
+
+            chatTime[source] = currentTick
+            lastChatMessage[source] = msg
+			
+            if isElement(source) then
+                local r, g, b = getPlayerNametagColor(source)
+                outputChatBox(playerName .. ': #FFFFFF' .. stripHex(msg), root, r, g, b, true)
+                outputServerLog("CHAT: " .. playerName .. ": " .. msg)
+            end
+        end
+    end
 )
 
 addEventHandler('onVehicleEnter', root,

--- a/[gameplay]/freeroam/fr_server.lua
+++ b/[gameplay]/freeroam/fr_server.lua
@@ -448,24 +448,21 @@ addEventHandler('onPlayerChat', root,
 	function(msg, type)
 		if type == 0 then
 			cancelEvent()
-			if not hasObjectPermissionTo(source, "command.kick") and not hasObjectPermissionTo(source, "command.mute") then
-				if chatTime[source] and chatTime[source] + tonumber(get("*chat/mainChatDelay")) > getTickCount() then
-					outputChatBox("Stop spamming main chat!", source, 255, 0, 0)
-					return
-				else
-					chatTime[source] = getTickCount()
-				end
-				if get("*chat/blockRepeatMessages") == "true" and lastChatMessage[source] and lastChatMessage[source] == msg then
+
+			local blockRepeats = get("*chat/blockRepeatMessages") == "true"
+
+			if blockRepeats then
+				if lastChatMessage[source] and lastChatMessage[source] == msg then
 					outputChatBox("Stop repeating yourself!", source, 255, 0, 0)
 					return
-				else
-					lastChatMessage[source] = msg
 				end
+				lastChatMessage[source] = msg
 			end
+
 			if isElement(source) then
 				local r, g, b = getPlayerNametagColor(source)
 				outputChatBox(getPlayerName(source) .. ': #FFFFFF' .. stripHex(msg), root, r, g, b, true)
-				outputServerLog( "CHAT: " .. getPlayerName(source) .. ": " .. msg )
+				outputServerLog("CHAT: " .. getPlayerName(source) .. ": " .. msg)
 			end
 		end
 	end


### PR DESCRIPTION
I noticed a bug in the freeroam game mode,  

        <setting name=“*chat/blockRepeatMessages” value=“true” />

but I was still able to spam the chat, I looked at the line of code and saw that something was wrong and fixed it