### PR TITLE
freeroam: fix false positive issue in `onPlayerTeleport` event and desync.

### DIFF
--- a/[gameplay]/freeroam/fr_client.lua
+++ b/[gameplay]/freeroam/fr_client.lua
@@ -34,7 +34,6 @@ local knifeRestrictionsOn = false
 -- Local settings received from server
 local g_settings = {}
 local _addCommandHandler = addCommandHandler
-local _setElementPosition = setElementPosition
 
 if not (g_PlayerData) then
     g_PlayerData = {}
@@ -135,7 +134,7 @@ local function setElementPosition(element,x,y,z)
 		setTimer(resetKnifing,5000,1)
 	end
 
-	_setElementPosition(element,x,y,z)
+	server.setElementPosition(element, x, y, z)
 end
 
 ---------------------------

--- a/[gameplay]/freeroam/fr_server.lua
+++ b/[gameplay]/freeroam/fr_server.lua
@@ -38,6 +38,7 @@ g_RPCFunctions = {
 	setElementAlpha = { option = 'alpha', descr = 'Changing your alpha' },
 	setElementInterior = true,
 	setCameraInterior = true,
+	setElementPosition = true,
 	setMySkin = { option = 'setskin', descr = 'Setting skin' },
 	setPedAnimation = { option = 'anim', descr = 'Setting an animation' },
 	setPedFightingStyle = { option = 'setstyle', descr = 'Setting fighting style' },

--- a/[gameplay]/freeroam/remote_player_call_validation_server.lua
+++ b/[gameplay]/freeroam/remote_player_call_validation_server.lua
@@ -63,6 +63,13 @@ g_RPCFunctionsValidation = {
         if (#{ ... } > 0) then return false end
         return true
     end,
+    setElementPosition = function(element, x, y, z)
+        if client ~= element and element ~= getPedOccupiedVehicle(client) then return false end
+        if type(x) ~= "number" then return false end
+        if type(y) ~= "number" then return false end
+        if type(z) ~= "number" then return false end
+        return true
+    end,
     setCameraInterior = function (thePlayer, interior, ...)
         if client ~= thePlayer then return false end
         if type(tonumber(interior)) ~= "number" then return false end


### PR DESCRIPTION
This PR fixes a false positive in the `onPlayerTeleport` event caused by the use of `setElementPosition` on the client side, as well as resolving desync issues resulting from improper use of the function on the wrong execution side (issue: https://github.com/multitheftauto/mtasa-blue/issues/3993).