### PR TITLE
Fix freecam controlState

### DIFF
--- a/[editor]/freecam/freecam.lua
+++ b/[editor]/freecam/freecam.lua
@@ -96,7 +96,7 @@ local function freecamFrame ()
 			speed = speed + acceleration
 	        speedKeyPressed = true
 	    end
-		if ( getKeyState ( options.key_backward ) or getPedControlState localPlayer, ( options.key_backward_veh ) ) and not getKeyState("arrow_d") then
+		if ( getKeyState ( options.key_backward ) or getPedControlState ( localPlayer, options.key_backward_veh ) ) and not getKeyState("arrow_d") then
 			speed = speed - acceleration
 	        speedKeyPressed = true
 	    end

--- a/[editor]/freecam/freecam.lua
+++ b/[editor]/freecam/freecam.lua
@@ -57,7 +57,7 @@ function getKeyState(key)
 		return mta_getKeyState(controlToKey[key])
 	else
 		-- We can use getControlState
-		return getPedControlState(key)
+		return getPedControlState(localPlayer, key)
 	end
 end
 
@@ -96,7 +96,7 @@ local function freecamFrame ()
 			speed = speed + acceleration
 	        speedKeyPressed = true
 	    end
-		if ( getKeyState ( options.key_backward ) or getPedControlState ( options.key_backward_veh ) ) and not getKeyState("arrow_d") then
+		if ( getKeyState ( options.key_backward ) or getPedControlState localPlayer, ( options.key_backward_veh ) ) and not getKeyState("arrow_d") then
 			speed = speed - acceleration
 	        speedKeyPressed = true
 	    end


### PR DESCRIPTION
Someone forget to put `localPlayer` in getPedControlState... (it was causing bugs)