### PR TITLE
 Fix typo and Lint: Indentation, shadowing

### DIFF
--- a/[editor]/edf/edf.lua
+++ b/[editor]/edf/edf.lua
@@ -674,7 +674,7 @@ function edfCloneElement(theElement, editorMode )
 	parametersTable = {}
 	parametersTable.position = {edfGetElementPosition(theElement)} or {0,0,0}
 	parametersTable.rotation = {edfGetElementRotation(theElement)} or {0,0,0}
-	parametersTable.scale = edfGetElementScale(theElement) or 2
+	parametersTable.scale = edfGetElementScale(theElement) or 1
 	parametersTable.interior = edfGetElementInterior(theElement) or 0
 	parametersTable.dimension = edfGetElementDimension(theElement) or 0
 	parametersTable.alpha = edfGetElementAlpha(theElement) or 255

--- a/[editor]/editor_gui/client/currentbrowser.lua
+++ b/[editor]/editor_gui/client/currentbrowser.lua
@@ -312,7 +312,7 @@ function setTableElementIDs(elemTable)
         local elementID = getElementID(v)
 		local numericID = ""
 		if getElementType(v) == "object" or getElementType(v) == "vehicle" or getElementType(v) == "ped" then
-        	numericID = "[" .. (getElementData(v, "model") or getElementModel(v) or "Unknown") .. "]"
+			numericID = "[" .. (getElementData(v, "model") or getElementModel(v) or "Unknown") .. "]"
 		end
         elementsWithIDs[k] = tostring(elementID) .. " " .. tostring(numericID)
     end

--- a/[editor]/editor_main/server/dumpxml.lua
+++ b/[editor]/editor_main/server/dumpxml.lua
@@ -16,7 +16,7 @@ end
 local specialSyncers = {
 	position = function() end,
 	rotation = function() end,
-	scale = function() end,
+	scale = function(element) return edf.edfGetElementScale(element) end,
 	dimension = function(element) return getElementData(element, "me:dimension") or 0 end,
 	interior = function(element) return edf.edfGetElementInterior(element) end,
 	alpha = function(element) return edf.edfGetElementAlpha(element) end,

--- a/[editor]/move_keyboard/move_keyboard.lua
+++ b/[editor]/move_keyboard/move_keyboard.lua
@@ -361,13 +361,13 @@ local function onClientRender_keyboard()
 
 		-- Scale up/down for objects
         if getElementType(selectedElement) == "object" then
-			local scale = getObjectScale(selectedElement)
+			local currentScale = getObjectScale(selectedElement)
             if getCommandState("element_scale_up") then
-                scale = scale + scaleIncrement
+                currentScale = currentScale + scaleIncrement
 			elseif getCommandState("element_scale_down") then
-                scale = scale - scaleIncrement
+                currentScale = currentScale - scaleIncrement
             end
-            setObjectScale(selectedElement, scale)
+            setObjectScale(selectedElement, currentScale)
         end
 	end
 end


### PR DESCRIPTION
Fixed a typo regarding default scale value
Fixed Indentation and shadowing of scale which is now currentScale