### PR TITLE
Added function getCurrentMapName()

### DIFF
--- a/[editor]/editor_main/meta.xml
+++ b/[editor]/editor_main/meta.xml
@@ -90,6 +90,9 @@
 	<!-- Incremental rotation with quaternions used by move_freecam, move_cursor, move_keyboard -->
 	<script src="client/rotation.lua" type="client" />
 
+	<!-- Exported server functions -->
+	<export function="getCurrentMapName" type="server" />
+
 	<!-- Exported client functions -->
 	<export function="startEditor" type="client" />
 	<export function="selectElement" type="client" />

--- a/[editor]/editor_main/server/saveloadtest_server.lua
+++ b/[editor]/editor_main/server/saveloadtest_server.lua
@@ -943,6 +943,10 @@ addEventHandler("onPlayerLogin", root,
 	end
 )
 
+function getCurrentMapName()
+	return loadedMap
+end
+
 function getBool(var,default)
 	local result = get(var)
 	if not result then


### PR DESCRIPTION
This can be useful if you want to save data directly into a map from an external resource in conjunction with quickSaveResource, saveResource, onMapOpened etc.

I couldn't find anything else that currently does this?

Main issue being that you get nil on your var if you can only use the above events to fetch the map name.
getCurrentMapName would simply return loadedMap and would always be accessible without reopening map when restarting the resource you are working on

`exports["editor_main"]:getCurrentMapName() --returns map name or false`