### PR TITLE
race: Fix error in base.lua

### DIFF
--- a/[gamemodes]/[race]/race/modes/base.lua
+++ b/[gamemodes]/[race]/race/modes/base.lua
@@ -272,7 +272,7 @@ function RaceMode:onPlayerReachCheckpoint(player, checkpointNum)
 			end
 
 			message = string.format("You finished %s %s.", rank, suffix)
-			killmessage = string.format("%s finished %s %s.", rank, suffix)
+			killmessage = string.format("%s finished %s %s.", name, rank, suffix)
 		end
 
 		if rank == 1 then

--- a/[gamemodes]/[race]/race/modes/base.lua
+++ b/[gamemodes]/[race]/race/modes/base.lua
@@ -271,8 +271,8 @@ function RaceMode:onPlayerReachCheckpoint(player, checkpointNum)
 				end
 			end
 
-			message = string.format("You finished %s %s.", rank, suffix)
-			killmessage = string.format("%s finished %s %s.", name, rank, suffix)
+			message = string.format("You finished %s%s.", rank, suffix)
+			killmessage = string.format("%s finished %s%s.", name, rank, suffix)
 		end
 
 		if rank == 1 then


### PR DESCRIPTION
Fixes #606.
Related to #595.
This PR also removes the unnecessary space that appeared after the change in PR #595 (`2 nd` -> `2nd`).