### PR TITLE
Fix Validation for setElementPosition RPC Function (Fixes 'Something went wrong.' when teleporting to interior through F1)

### DIFF
--- a/[gameplay]/freeroam/remote_player_call_validation_server.lua
+++ b/[gameplay]/freeroam/remote_player_call_validation_server.lua
@@ -65,6 +65,12 @@ g_RPCFunctionsValidation = {
     end,
     setElementPosition = function(element, x, y, z)
         if client ~= element and element ~= getPedOccupiedVehicle(client) then return false end
+        -- outputDebugString("DEBUG setElementPosition: type(x)=" .. type(x) .. "; value=" .. tostring(x), 3)
+        -- outputDebugString("DEBUG setElementPosition: type(y)=" .. type(y) .. "; value=" .. tostring(y), 3)
+        -- outputDebugString("DEBUG setElementPosition: type(z)=" .. type(z) .. "; value=" .. tostring(z), 3)
+        x = tonumber(x)
+        y = tonumber(y)
+        z = tonumber(z)
         if type(x) ~= "number" then return false end
         if type(y) ~= "number" then return false end
         if type(z) ~= "number" then return false end


### PR DESCRIPTION
The reason the "Something went wrong." message appeared was because the function setElementPosition was receiving the wrong argument type. It took the values directly from the interiors.xml file, which are string values, but this function required number values. So, to fix it, these values have to be converted to numbers before the RPC Functions Validation.

**Summary:**

This pull request improves the validation logic for the setElementPosition function in the g_RPCFunctionsValidation table. The changes ensure that the parameters x, y, and z are properly converted to numbers and validated before proceeding. This prevents invalid data from being processed and enhances the stability of the function.

**Changes:**

Added tonumber() conversion for x, y, and z to handle cases where these values are passed as strings.
Included debug messages (commented out) for easier troubleshooting if needed in the future.