### PR TITLE
admin: Fix panel FPS range label width + Fixed lint error

### DIFF
--- a/[admin]/admin/client/gui/admin_main.lua
+++ b/[admin]/admin/client/gui/admin_main.lua
@@ -269,7 +269,7 @@ y=y+B  aTab1.VehicleHealth	= guiCreateLabel ( 0.26, y, 0.25, 0.04, "Vehicle Heal
 		aTab3.FPSCurrent	= guiCreateLabel ( 0.05, 0.65, 0.25, 0.04, "FPS Limit: 38", true, aTab3.Tab )
 		aTab3.FPS			= guiCreateEdit ( 0.35, 0.65, 0.135, 0.04, "38", true, aTab3.Tab )
 		aTab3.FPSSet		= guiCreateButton ( 0.50, 0.65, 0.10, 0.04, "Set", true, aTab3.Tab, "setfpslimit" )
-							guiCreateLabel ( 0.63, 0.65, 0.1, 0.04, "( 25-32767 )", true, aTab3.Tab )
+							guiCreateLabel ( 0.63, 0.65, 0.12, 0.04, "( 25-32767 )", true, aTab3.Tab )
 
 
 		aTab4 = {}

--- a/[editor]/editor_main/client/elementcreation.lua
+++ b/[editor]/editor_main/client/elementcreation.lua
@@ -39,7 +39,7 @@ function doCreateElement ( elementType, resourceName, creationParameters, attach
 	creationParameters = creationParameters or {}
 	if not creationParameters.position then
 		local targetX, targetY, targetZ = processCameraLineOfSight()
-		if not elementType == "object" or not elementType == "vehicle" then
+		if elementType ~= "object" and elementType ~= "vehicle" then
 			creationParameters.position = nil
 		else
 			creationParameters.position = {targetX, targetY, targetZ + .5}


### PR DESCRIPTION
This is a minimal change.

Increase the FPS range label width from 0.1 to 0.12 to prevent the label text from being cut off.