### PR TITLE
editor: prevent vehicle damage and blowVehicle when in basic test mode

### DIFF
--- a/[editor]/editor_gui/client/test.lua
+++ b/[editor]/editor_gui/client/test.lua
@@ -223,6 +223,8 @@ function basicTest()
 		editor_main.resume(true)
 		inBasicTest = false
 		removeEventHandler("onClientPlayerDamage", localPlayer, noDamageInBasicTest)
+		removeEventHandler("onClientVehicleDamage", root, noDamageInBasicTest)
+		triggerServerEvent("onBasicTestEnd", localPlayer)
 		toggleControl("fire", true)
 		toggleControl("enter_exit", true)
 		toggleControl("enter_passenger", true)
@@ -247,6 +249,8 @@ function basicTest()
 		toggleControl("enter_passenger", false)
 		inBasicTest = true
 		addEventHandler("onClientPlayerDamage", localPlayer, noDamageInBasicTest)
+		addEventHandler("onClientVehicleDamage", root, noDamageInBasicTest)
+		triggerServerEvent("onBasicTestStart", localPlayer)
 		outputChatBox("Press F6 to leave basic test", 0, 255, 0)
 		bindControl ( "toggle_basictest", "down", basicTest )
 

--- a/[editor]/editor_gui/meta.xml
+++ b/[editor]/editor_gui/meta.xml
@@ -76,6 +76,7 @@
 	<!-- Server-side logic -->
 	<script src="server/guiserverlink.lua" type="server" />
 	<script src="server/interface.lua" type="server" />
+	<script src="server/override.lua" type="server" />
 
 	<!-- GUI icons -->
 	<!-- Most icons courtesy of the Evaraldo Crystal icon gallery -->

--- a/[editor]/editor_gui/server/override.lua
+++ b/[editor]/editor_gui/server/override.lua
@@ -1,0 +1,31 @@
+local playersInBasicTest = {}
+
+addEvent("onBasicTestStart", true)
+addEventHandler("onBasicTestStart", root, function()
+	if client and client ~= source then
+		return
+	end
+	playersInBasicTest[source] = true
+end)
+
+addEvent("onBasicTestEnd", true)
+addEventHandler("onBasicTestEnd", root, function()
+	if client and client ~= source then
+		return
+	end
+	playersInBasicTest[source] = nil
+end)
+
+addEventHandler("onPlayerQuit", root, function()
+	playersInBasicTest[source] = nil
+end)
+
+addDebugHook("preFunction", function(sourceResource, functionName, isAllowedByACL, luaFilename, luaLineNumber, ...)
+	if functionName == "blowVehicle" then
+		for player, _ in pairs(playersInBasicTest) do
+			if isElement(player) then
+				return "skip"
+			end
+		end
+	end
+end, {"blowVehicle"})


### PR DESCRIPTION
As title above this prevents all vehicle damage when in basic test mode (f6) and also blocks serverside blowVehicle requests via admin panel and should fix #651 