### PR TITLE
editor_gui: Fix the last row not being displayed

### DIFF
--- a/[editor]/editor_gui/client/browser/browserList.lua
+++ b/[editor]/editor_gui/client/browser/browserList.lua
@@ -1,7 +1,7 @@
 browserList = {}
 browserList_mt = { __index = browserList }
 local activatedBrowsers = {}
-local ROW_HEIGHT = 14
+local ROW_HEIGHT = 14.1
 local keyUp,keyDown,ignore
 --NOTE: All functions lack necessary checks to verify valid args, its intended for internal use only
 -------
@@ -59,7 +59,7 @@ local function updateActivatedBrowsers()
 			local targetKey = startKey + self.gridlistRowCount - 1
 			--set the text
 			local i = startKey
-			while i ~= targetKey do
+			while i <= targetKey do
 				rowColumns = self.rowList[i]
 				if type(rowColumns) == "table" then
 					local pos = guiGridListAddRow ( self.gridlist )
@@ -192,7 +192,7 @@ function browserList:setRows(rowTable)
 	self.currentStartKey = 1
 	self.rowCount = #rowTable --total number of rows
 	self.rowList = rowTable
-	self.scrollDistance = self.rowCount - self.gridlistRowCount
+	self.scrollDistance = self.rowCount - self.gridlistRowCount + 1
 	if self.scrollDistance == 0 then
 		self.scrollDistance = 1
 	end
@@ -220,7 +220,7 @@ function browserList:setRows(rowTable)
 	end
 	local i = 1
 	local target = self.gridlistRowCount + 2
-	while i ~= target do
+	while i <= target do
 		local rowColumns = rowTable[i]
 		if type(rowColumns) == "table" then
 			local pos = guiGridListAddRow ( self.gridlist )


### PR DESCRIPTION
Tried to not mess much with these hardcodded values, if you got any better solution than this let me know
before:
last row missing should be: object (vgncarshade1) (86) 
<img width="615/4" height="329/4" alt="image" src="https://github.com/user-attachments/assets/7648d054-0967-4e9b-9f84-8df37aad6c26" />
<img width="637/4" height="358/4" alt="image" src="https://github.com/user-attachments/assets/305c9581-2cd0-4c3e-a747-eb12108d0df0" />

after:
<img width="614/6" height="538/6" alt="image" src="https://github.com/user-attachments/assets/9486db5f-3390-4720-a3a7-5f12e73b9f2f" />
<img width="637/6" height="438/6" alt="image" src="https://github.com/user-attachments/assets/dcc29923-48a2-4845-9365-2e0352951791" />
