### PR TITLE
race: add new settings to control vehicle physics behavior

### DIFF
--- a/[gamemodes]/[race]/race/edf/race.edf
+++ b/[gamemodes]/[race]/race/edf/race.edf
@@ -7,6 +7,8 @@
 	<setting name="respawntime" friendlyname="Respawn delay" type="natural" description="Time from death to respawn in seconds. Default is 5." default="5" required="true"/>
 	<setting name="autopimp" friendlyname="Auto pimp" type="selection:true,false" default="true" description="Whether to apply a selection of visual upgrades to vehicles." required="false"/>
 	<setting name="firewater" friendlyname="Fire water" type="selection:true,false" default="false" description="Whether to explode the player when entering the water." required="false"/>
+	<setting name="vehicle_physics_mode" friendlyname="Vehicle physics mode" type="selection:fixed,legacy" description="Sets the vehicle physics mode. Use fixed (recommended) for FPS-independent physics, or legacy to use FPS-dependent physics." required="false"/>
+	<setting name="vehicle_physics_fps" friendlyname="Vehicle physics FPS" type="string" description="FPS limit to use when vehicle physics mode is set to legacy. This setting changes the limit: -1 = leave unchanged, 0 = unlimited, 25+ = specific limit." required="false"/>
 
 	<element name="spawnpoint" friendlyname="Spawnpoint" icon="edf/spawnpoint.png">
 		<data name="position" type="coord3d" default="0,0,0" />

--- a/[gamemodes]/[race]/race/meta.xml
+++ b/[gamemodes]/[race]/race/meta.xml
@@ -319,6 +319,20 @@
 					desc="Set to true to show the map author name on the travelling screen."
 					/>
 
+		<setting name="*vehicle_physics_mode" value="fixed"
+					friendlyname="Vehicle physics mode"
+					group="Gameplay"
+					accept="fixed,legacy"
+					desc="Sets the vehicle physics mode. Use fixed (recommended) for FPS-independent physics, or legacy to use FPS-dependent physics."
+					/>
+
+		<setting name="*vehicle_physics_fps" value="-1"
+					friendlyname="Vehicle physics FPS"
+					group="Gameplay"
+					accept="-1,0,25-32767"
+					desc="FPS limit to use when vehicle physics mode is set to legacy. This setting changes the limit: -1 = leave unchanged, 0 = unlimited, 25+ = specific limit."
+					/>
+
         <setting name="*ghostmode_map_can_override" friendlyname="Ghost mode map override" group="Gameplay" value="true" accept="false,true" desc="Set to true to allow the map to override this setting"/>
 		<setting name="*skins_map_can_override"  friendlyname="Driver skin map override" group="Graphics" value="true" accept="false,true" desc="Set to true to allow the map to override this setting"/>
 		<setting name="*vehicleweapons_map_can_override"  friendlyname="Vehicle weapons map override" group="Gameplay" value="true" accept="false,true" desc="Set to true to allow the map to override this setting"/>
@@ -329,6 +343,9 @@
 
 		<setting name="*ghostmode_warning_if_map_override"  friendlyname="Ghost mode override warning" group="Gameplay" value="true" accept="false,true" desc="Set to true to issue a warning to players in the chatbox, if the map overrides this setting"/>
 		<setting name="*vehicleweapons_warning_if_map_override"  friendlyname="Vehicle weapons override warning" group="Gameplay" value="true" accept="false,true" desc="Set to true to issue a warning to players in the chatbox, if the map overrides this setting"/>
+
+		<setting name="*vehicle_physics_mode_map_can_override"  friendlyname="Vehicle physics mode map override" group="Gameplay" value="true" accept="false,true" desc="Set to true to allow the map to override this setting"/>
+		<setting name="*vehicle_physics_fps_map_can_override"  friendlyname="Vehicle physics FPS map override" group="Gameplay" value="true" accept="false,true" desc="Set to true to allow the map to override this setting"/>
     </settings>
 
 

--- a/[gamemodes]/[race]/race/meta.xml
+++ b/[gamemodes]/[race]/race/meta.xml
@@ -319,7 +319,7 @@
 					desc="Set to true to show the map author name on the travelling screen."
 					/>
 
-		<setting name="*vehicle_physics_mode" value="fixed"
+		<setting name="*vehicle_physics_mode" value="legacy"
 					friendlyname="Vehicle physics mode"
 					group="Gameplay"
 					accept="fixed,legacy"

--- a/[gamemodes]/[race]/race/race_server.lua
+++ b/[gamemodes]/[race]/race/race_server.lua
@@ -124,7 +124,7 @@ function cacheGameOptions()
 	g_GameOptions.vehicleweapons_warning_if_map_override	= getBool('race.vehicleweapons_warning_if_map_override',true)
 	g_GameOptions.hunterminigun_map_can_override	= getBool('race.hunterminigun_map_can_override',true)
 	g_GameOptions.endmapwhenonlyspectators	= getBool('race.endmapwhenonlyspectators',true)
-	g_GameOptions.vehicle_physics_mode = getString('race.vehicle_physics_mode','fixed')
+	g_GameOptions.vehicle_physics_mode = getString('race.vehicle_physics_mode','legacy')
 	g_GameOptions.vehicle_physics_fps = getNumber('race.vehicle_physics_fps',-1)
 	g_GameOptions.vehicle_physics_mode_map_can_override = getBool('race.vehicle_physics_mode_map_can_override',true)
 	g_GameOptions.vehicle_physics_fps_map_can_override = getBool('race.vehicle_physics_fps_map_can_override',true)
@@ -225,13 +225,24 @@ function cacheMapOptions(map)
 		g_MapOptions.vehicle_physics_fps = g_GameOptions.vehicle_physics_fps
 	end
 
-	if g_MapOptions.vehicle_physics_mode == "legacy" then
+	if g_MapOptions.vehicle_physics_mode == "fixed" then
+		if g_OriginalVehiclePhysicsGlitchState == nil then
+			g_OriginalVehiclePhysicsGlitchState = isGlitchEnabled("vehicle_rapid_stop")
+		end
+
+		setGlitchEnabled("vehicle_rapid_stop", false)
+
+		if g_OriginalFPSLimit ~= nil then
+			setFPSLimit(g_OriginalFPSLimit)
+			g_OriginalFPSLimit = nil
+		end
+	else
 		if g_OriginalVehiclePhysicsGlitchState == nil then
 			g_OriginalVehiclePhysicsGlitchState = isGlitchEnabled("vehicle_rapid_stop")
 		end
 
 		setGlitchEnabled("vehicle_rapid_stop", true)
-		
+
 		if g_MapOptions.vehicle_physics_fps >= 0 then
 			if g_OriginalFPSLimit == nil then
 				g_OriginalFPSLimit = getFPSLimit()
@@ -242,17 +253,6 @@ function cacheMapOptions(map)
 				setFPSLimit(g_OriginalFPSLimit)
 				g_OriginalFPSLimit = nil
 			end
-		end
-	else
-		if g_OriginalVehiclePhysicsGlitchState == nil then
-			g_OriginalVehiclePhysicsGlitchState = isGlitchEnabled("vehicle_rapid_stop")
-		end
-		
-		setGlitchEnabled("vehicle_rapid_stop", false)
-		
-		if g_OriginalFPSLimit ~= nil then
-			setFPSLimit(g_OriginalFPSLimit)
-			g_OriginalFPSLimit = nil
 		end
 	end
 end

--- a/[gamemodes]/[race]/race/race_server.lua
+++ b/[gamemodes]/[race]/race/race_server.lua
@@ -9,6 +9,9 @@ g_VehicleClothes = {
 
 g_CurrentRaceMode = nil
 
+g_OriginalFPSLimit = nil
+g_OriginalVehiclePhysicsGlitchState = nil
+
 g_Spawnpoints = {}			-- { i = { position={x, y, z}, rotation={x, y, z}, vehicle=vehicleID, paintjob=paintjob, upgrades={...} } }
 g_Checkpoints = {}			-- { i = { position={x, y, z}, size=size, color={r, g, b}, type=type, vehicle=vehicleID, paintjob=paintjob, upgrades={...} } }
 g_Objects = {}				-- { i = { position={x, y, z}, rotation={x, y, z}, model=modelID } }
@@ -121,6 +124,10 @@ function cacheGameOptions()
 	g_GameOptions.vehicleweapons_warning_if_map_override	= getBool('race.vehicleweapons_warning_if_map_override',true)
 	g_GameOptions.hunterminigun_map_can_override	= getBool('race.hunterminigun_map_can_override',true)
 	g_GameOptions.endmapwhenonlyspectators	= getBool('race.endmapwhenonlyspectators',true)
+	g_GameOptions.vehicle_physics_mode = getString('race.vehicle_physics_mode','fixed')
+	g_GameOptions.vehicle_physics_fps = getNumber('race.vehicle_physics_fps',-1)
+	g_GameOptions.vehicle_physics_mode_map_can_override = getBool('race.vehicle_physics_mode_map_can_override',true)
+	g_GameOptions.vehicle_physics_fps_map_can_override = getBool('race.vehicle_physics_fps_map_can_override',true)
 	if g_GameOptions.statskey ~= 'name' and g_GameOptions.statskey ~= 'serial' then
 		outputWarning( "statskey is not set to 'name' or 'serial'" )
 		g_GameOptions.statskey = 'name'
@@ -149,6 +156,8 @@ function cacheMapOptions(map)
 	g_MapOptions.firewater		= map.firewater == 'true'
 	g_MapOptions.classicchangez	= map.classicchangez == 'true'
 	g_MapOptions.hunterminigun	= map.hunterminigun == 'true'
+	g_MapOptions.vehicle_physics_mode = map.vehicle_physics_mode or g_GameOptions.vehicle_physics_mode
+	g_MapOptions.vehicle_physics_fps = tonumber(map.vehicle_physics_fps) or g_GameOptions.vehicle_physics_fps
 
 	outputDebug("MISC", "duration = "..g_MapOptions.duration.."  respawn = "..g_MapOptions.respawn.."  respawntime = "..tostring(g_MapOptions.respawntime).."  time = "..g_MapOptions.time.."  weather = "..g_MapOptions.weather)
 
@@ -205,6 +214,47 @@ function cacheMapOptions(map)
 	if not map.hunterminigun or not g_GameOptions.hunterminigun_map_can_override then
 		g_MapOptions.hunterminigun = g_GameOptions.hunterminigun
 	end
+
+	-- Set vehicle_physics_mode from g_GameOptions if not defined in the map, or map override not allowed
+	if not map.vehicle_physics_mode or not g_GameOptions.vehicle_physics_mode_map_can_override then
+		g_MapOptions.vehicle_physics_mode = g_GameOptions.vehicle_physics_mode
+	end
+
+	-- Set vehicle_physics_fps from g_GameOptions if not defined in the map, or map override not allowed
+	if not map.vehicle_physics_fps or not g_GameOptions.vehicle_physics_fps_map_can_override then
+		g_MapOptions.vehicle_physics_fps = g_GameOptions.vehicle_physics_fps
+	end
+
+	if g_MapOptions.vehicle_physics_mode == "legacy" then
+		if g_OriginalVehiclePhysicsGlitchState == nil then
+			g_OriginalVehiclePhysicsGlitchState = isGlitchEnabled("vehicle_rapid_stop")
+		end
+
+		setGlitchEnabled("vehicle_rapid_stop", true)
+		
+		if g_MapOptions.vehicle_physics_fps >= 0 then
+			if g_OriginalFPSLimit == nil then
+				g_OriginalFPSLimit = getFPSLimit()
+			end
+			setFPSLimit(g_MapOptions.vehicle_physics_fps)
+		else
+			if g_OriginalFPSLimit ~= nil then
+				setFPSLimit(g_OriginalFPSLimit)
+				g_OriginalFPSLimit = nil
+			end
+		end
+	else
+		if g_OriginalVehiclePhysicsGlitchState == nil then
+			g_OriginalVehiclePhysicsGlitchState = isGlitchEnabled("vehicle_rapid_stop")
+		end
+		
+		setGlitchEnabled("vehicle_rapid_stop", false)
+		
+		if g_OriginalFPSLimit ~= nil then
+			setFPSLimit(g_OriginalFPSLimit)
+			g_OriginalFPSLimit = nil
+		end
+	end
 end
 
 
@@ -238,6 +288,8 @@ function loadMap(res)
 	g_SavedMapSettings.classicchangez	= map.classicchangez
 	g_SavedMapSettings.firewater		= map.firewater
 	g_SavedMapSettings.hunterminigun	= map.hunterminigun
+	g_SavedMapSettings.vehicle_physics_mode		= map.vehicle_physics_mode
+	g_SavedMapSettings.vehicle_physics_fps		= map.vehicle_physics_fps
 
 	cacheMapOptions(g_SavedMapSettings)
 
@@ -727,6 +779,16 @@ function unloadAll()
 		clientCall(root, 'unloadAll')
 	end
 	TimerManager.destroyTimersFor("map")
+
+	if g_OriginalFPSLimit ~= nil then
+		setFPSLimit(g_OriginalFPSLimit)
+		g_OriginalFPSLimit = nil
+	end
+
+	if g_OriginalVehiclePhysicsGlitchState ~= nil then
+		setGlitchEnabled("vehicle_rapid_stop", g_OriginalVehiclePhysicsGlitchState)
+		g_OriginalVehiclePhysicsGlitchState = nil
+	end
 
 	Countdown.destroyAll()
 

--- a/[gamemodes]/[race]/race/racemap.lua
+++ b/[gamemodes]/[race]/race/racemap.lua
@@ -7,7 +7,7 @@ g_MapObjAttrs = {
 g_MapSettingNames = table.create(
 	{'time', 'weather', 'respawn', 'respawntime', 'duration', 'skins', 'bikehats', 'bikehatchance', 'carhats', 'carhatchance',
 	 'hairstyles', 'glasses', 'glasseschance', 'shirts', 'trousers', 'shoes',
-	 'ghostmode', 'vehicleweapons', 'autopimp', 'firewater', 'classicchangez', 'hunterminigun'},
+	 'ghostmode', 'vehicleweapons', 'autopimp', 'firewater', 'classicchangez', 'hunterminigun', 'vehicle_physics_mode', 'vehicle_physics_fps'},
 	true
 )
 


### PR DESCRIPTION
This PR adds new settings that can be configured globally by the server or per map to control vehicle physics behavior. By default, they do not change the current behavior unless set in race or map settings. These settings were added to fix issues caused by multitheftauto/mtasa-blue#4243, which broke many custom maps and made them unfinishable. They allow server owners and mappers to bring back the old physics on specific maps by disabling the fix and setting the FPS those maps were designed for, without affecting other maps. The old behavior can also be enabled globally.

**New settings:**
- **`vehicle_physics_mode`**  
Controls physics behavior. `fixed` for FPS-independent physics, or `legacy` to restore the old behavior. Default is `fixed`.
- **`vehicle_physics_fps`**  
Sets the FPS limit when `vehicle_physics_mode` is set to `legacy`. `-1` to keep the current limit, or set a specific FPS value. The original FPS limit is restored when the map or race resource stops. Default is `-1`.
- **`vehicle_physics_mode_map_can_override`** and **`vehicle_physics_fps_map_can_override`**  
Allow maps to override the global `vehicle_physics_mode` and `vehicle_physics_fps` values. Default is `true`.