### PR TITLE
editor_main: Fix an issue with importing elements from other resources

### DIFF
--- a/[editor]/editor_main/client/elementcreation.lua
+++ b/[editor]/editor_main/client/elementcreation.lua
@@ -79,5 +79,5 @@ function doCloneElement ( element, attachMode )
 	if exports["editor_gui"]:sx_getOptionData("randomizeRotation") == true then
 		rotationData = getRandomRotation()
 	end
-	triggerServerEvent( "doCloneElement", element, attachMode, rotationData )
+	triggerServerEvent( "doCloneElement", element, attachMode, false, rotationData )
 end

--- a/[editor]/editor_main/server/createdestroy.lua
+++ b/[editor]/editor_main/server/createdestroy.lua
@@ -19,7 +19,7 @@ function setupNewElement(element, creatorResource, creatorClient, attachLater,sh
 	makeElementStatic( element )
 	assignID ( element )
 	triggerEvent ( "onElementCreate_undoredo", element )
-	if attachLater then
+	if attachLater and creatorClient then
 		setTimer(triggerClientEvent, WAIT_LOAD_INTERVAL, 1, creatorClient, "doSelectElement", element, selectionSubmode, shortcut )
 	end
 	justCreated[element] = true --mark it so undoredo ignores first placement
@@ -56,7 +56,7 @@ addEventHandler ( "doCreateElement", root,
 )
 
 addEventHandler ( "doCloneElement", root,
-	function (attachMode,rotationData,creator)
+	function (attachMode, creator, rotationData)
 		if client and not isPlayerAllowedToDoEditorAction(client,"createElement") then
 			editor_gui.outputMessage ("You don't have permissions to clone an element!", client,255,0,0)
 			return


### PR DESCRIPTION
before it throws an error when using `call( getResourceFromName( "editor", "import", thisResource)` because in doCloneElement, the second argument should be creator not rotationData
 https://github.com/multitheftauto/mtasa-resources/blob/2e867491a1f4bf9da678ade4843e58f0d2ec7c94/%5Beditor%5D/editor_main/server/createdestroy.lua#L58-L59
<img width="833" height="102" alt="image" src="https://github.com/user-attachments/assets/09555453-5501-4078-8d3c-31f10f1b205c" />
