### PR TITLE
admin & admin2: set hasObjectPermissionTo defaultPermission to false

### DIFF
--- a/[admin]/admin/server/admin_commands.lua
+++ b/[admin]/admin/server/admin_commands.lua
@@ -58,7 +58,7 @@ end
 function aCommand ( admin, command, ... )
 	local call = _commands[command]
 	if ( call ) then
-		if ( hasObjectPermissionTo ( admin, "command."..call.action ) ) then
+		if ( hasObjectPermissionTo ( admin, "command."..call.action, false ) ) then
 			local arg, errormsg = aCommandToArgs ( { ... }, call.args )
 			if not errormsg then
 				if ( call.type == "player" ) then triggerEvent ( "aPlayer", admin, arg[1], call.action, arg[2], arg[3], arg[4] )

--- a/[admin]/admin/server/admin_screenshot.lua
+++ b/[admin]/admin/server/admin_screenshot.lua
@@ -42,7 +42,7 @@ addEventHandler("aScreenShot",root,
 		if not isElement(admin) then return end
 		if not action then return end
 		local right = rights[action]
-		if not right or not hasObjectPermissionTo(admin,"command."..right) then return end
+		if not right or not hasObjectPermissionTo(admin,"command."..right, false) then return end
 		if action == "new" then
 			if not isElement(player) then return end
 			if screenshots[player] then

--- a/[admin]/admin/server/admin_server.lua
+++ b/[admin]/admin/server/admin_server.lua
@@ -53,7 +53,7 @@ function aHandleIP2CUpdate()
 
     for playerID = 1, #playersTable do
         local playerElement = playersTable[playerID]
-        local hasAdminPermission = hasObjectPermissionTo(playerElement, "general.adminpanel")
+        local hasAdminPermission = hasObjectPermissionTo(playerElement, "general.adminpanel", false)
 
         if hasAdminPermission then
             
@@ -89,7 +89,7 @@ addEventHandler ( "onResourceStart", root, function ( resource )
 	if ( resource ~= getThisResource() ) then
 		local resourceName = getResourceName(resource)
 		for id, player in ipairs(getElementsByType("player")) do
-			if ( hasObjectPermissionTo ( player, "general.tab_resources" ) ) then
+			if ( hasObjectPermissionTo ( player, "general.tab_resources", false ) ) then
 				triggerClientEvent ( player, "aClientResourceStart", root, resourceName )
 			end
 		end
@@ -107,7 +107,7 @@ addEventHandler ( "onResourceStart", root, function ( resource )
 	aSetupCommands()
 	for id, player in ipairs ( getElementsByType ( "player" ) ) do
 		aPlayerInitialize ( player )
-		if ( hasObjectPermissionTo ( player, "general.adminpanel" ) ) then
+		if ( hasObjectPermissionTo ( player, "general.adminpanel", false ) ) then
 			notifyPlayerLoggedIn(player)
 		end
 	end
@@ -257,7 +257,7 @@ addEventHandler ( "onResourceStop", root, function ( resource )
 	if ( resource ~= getThisResource() ) then
 		local resourceName = getResourceName(resource)
 		for id, player in ipairs(getElementsByType("player")) do
-			if ( hasObjectPermissionTo ( player, "general.tab_resources" ) ) then
+			if ( hasObjectPermissionTo ( player, "general.tab_resources", false ) ) then
 				triggerClientEvent ( player, "aClientResourceStop", root, resourceName )
 			end
 		end
@@ -431,8 +431,8 @@ addEventHandler ( "onPlayerJoin", root, function ()
 	end
 	aPlayerInitialize ( source )
 	for id, player in ipairs(getElementsByType("player")) do
-		if ( hasObjectPermissionTo ( player, "general.adminpanel" ) ) then
-			triggerClientEvent ( player, "aClientPlayerJoin", source, getPlayerIP ( source ), getPlayerAccountName ( source ), getPlayerSerial ( source ), hasObjectPermissionTo ( source, "general.adminpanel" ), aPlayers[source]["country"] )
+		if ( hasObjectPermissionTo ( player, "general.adminpanel", false ) ) then
+			triggerClientEvent ( player, "aClientPlayerJoin", source, getPlayerIP ( source ), getPlayerAccountName ( source ), getPlayerSerial ( source ), hasObjectPermissionTo ( source, "general.adminpanel", false ), aPlayers[source]["country"] )
 		end
 	end
 	setPedGravity ( source, getGravity() )
@@ -512,7 +512,7 @@ function aPlayerSerialCheck ( player, result )
 end
 
 addEventHandler ( "onPlayerLogin", root, function ( previous, account, auto )
-	if ( hasObjectPermissionTo ( source, "general.adminpanel" ) ) then
+	if ( hasObjectPermissionTo ( source, "general.adminpanel", false ) ) then
 		triggerEvent ( "aPermissions", source )
 		notifyPlayerLoggedIn( source )
 	end
@@ -545,7 +545,7 @@ end )
 addCommandHandler ( "unregister", function ( player, command, arg1 )
 	local username = arg1 or ""
 	local result = "failed - No permission"
-	if ( hasObjectPermissionTo ( player, "function.removeAccount" ) ) then
+	if ( hasObjectPermissionTo ( player, "function.removeAccount", false ) ) then
 		local account = getAccount ( username )
 		if not account then
 			result = "failed - Does not exist"
@@ -574,7 +574,7 @@ function getAdminNameForLog(player)
 end
 
 function aAdminMenu ( player, command )
-	if ( hasObjectPermissionTo ( player, "general.adminpanel" ) ) then
+	if ( hasObjectPermissionTo ( player, "general.adminpanel", false ) ) then
 		triggerClientEvent ( player, "aClientAdminMenu", root )
 		aPlayers[player]["chat"] = true
 	end
@@ -631,7 +631,7 @@ addEventHandler ( "aTeam", root, function ( action, name, r, g, b )
 	if checkClient( "command."..action, source, 'aTeam', action ) then
 		return
 	end
-	if ( hasObjectPermissionTo ( client or source, "command."..action ) ) then
+	if ( hasObjectPermissionTo ( client or source, "command."..action, false ) ) then
 		mdata = ""
 		if ( action == "createteam" ) then
 			local success
@@ -954,7 +954,7 @@ addEventHandler ( "aPlayer", root, function ( player, action, data, additional, 
 	if not isElement( player ) then
 		return	-- Ignore if player is no longer valid
 	end
-	if ( hasObjectPermissionTo ( client or source, "command."..action ) ) then
+	if ( hasObjectPermissionTo ( client or source, "command."..action, false ) ) then
 		local admin = source
 		local mdata = ""
 		local more = ""
@@ -1168,7 +1168,7 @@ addEventHandler ( "aPlayer", root, function ( player, action, data, additional, 
 						action = "adminr"
 					end
 					for id, p in ipairs ( getElementsByType ( "player" ) ) do
-						if ( hasObjectPermissionTo ( p, "general.adminpanel" ) ) then triggerEvent ( "aSync", p, "admins" ) end
+						if ( hasObjectPermissionTo ( p, "general.adminpanel", false ) ) then triggerEvent ( "aSync", p, "admins" ) end
 					end
 				else
 					outputChatBox ( "Error - Admin group not initialized. Please reinstall admin resource.", source, 255, 0 ,0 )
@@ -1263,7 +1263,7 @@ end
 addEvent ( "aVehicle", true )
 addEventHandler ( "aVehicle", root, function ( player, action, data )
 	if checkClient( "command."..action, source, 'aVehicle', action ) then return end
-	if ( hasObjectPermissionTo ( client or source, "command."..action ) ) then
+	if ( hasObjectPermissionTo ( client or source, "command."..action, false ) ) then
 		if ( not player ) then return end
 		local vehicle = getPedOccupiedVehicle ( player )
 		if ( vehicle ) then
@@ -1347,7 +1347,7 @@ addEvent ( "aResource", true )
 addEventHandler ( "aResource", root, function ( name, action )
 	if checkClient( "command."..action, source, 'aResource', action ) then return end
 	local pname = getPlayerName ( source )
-	if ( hasObjectPermissionTo ( client or source, "command."..action ) ) then
+	if ( hasObjectPermissionTo ( client or source, "command."..action, false ) ) then
 		local text = ""
 		if ( action == "start" ) then
 			if ( startResource ( getResourceFromName ( name ), true ) ) then
@@ -1385,7 +1385,7 @@ end )
 addEvent ( "aServer", true )
 addEventHandler ( "aServer", root, function ( action, data, data2 )
 	if checkClient( "command."..action, source, 'aServer', action ) then return end
-	if ( hasObjectPermissionTo ( client or source, "command."..action ) ) then
+	if ( hasObjectPermissionTo ( client or source, "command."..action, false ) ) then
 		local mdata = tostring ( data )
 		local mdata2 = ""
 		if ( action == "setgame" ) then
@@ -1536,7 +1536,7 @@ function ( action, data )
 		aReports[id].read = false
 		-- PM all admins to say a new message has arrived
 		for _, p in ipairs ( getElementsByType ( "player" ) ) do
-			if ( hasObjectPermissionTo ( p, "general.adminpanel" ) ) then
+			if ( hasObjectPermissionTo ( p, "general.adminpanel", false ) ) then
 				outputChatBox( "New Admin message from " .. aReports[id].author .. " (" .. aReports[id].subject .. ")", p, 255, 0, 0 )
 			end
 		end
@@ -1545,7 +1545,7 @@ function ( action, data )
 			table.remove( aReports, 1 )
 		end
 	end
-	if ( hasObjectPermissionTo ( client or source, "general.adminpanel" ) ) then
+	if ( hasObjectPermissionTo ( client or source, "general.adminpanel", false ) ) then
 		if ( action == "get" ) then
 			triggerClientEvent ( source, "aMessage", source, "get", aReports, get("reportsEnabled") )
 		elseif ( action == "read" ) then
@@ -1561,7 +1561,7 @@ function ( action, data )
 		end
 	end
 	for id, p in ipairs ( getElementsByType ( "player" ) ) do
-		if ( hasObjectPermissionTo ( p, "general.adminpanel" ) ) then
+		if ( hasObjectPermissionTo ( p, "general.adminpanel", false ) ) then
 			triggerEvent ( "aSync", p, "messages" )
 		end
 	end
@@ -1572,7 +1572,7 @@ addEvent ( "aModdetails", true )
 addEventHandler ( "aModdetails", resourceRoot, function ( action, player )
 	if source ~= resourceRoot then return end
 	if checkClient( false, client, 'aModdetails', action ) then return end
-	if ( hasObjectPermissionTo ( client, "general.adminpanel" ) ) then
+	if ( hasObjectPermissionTo ( client, "general.adminpanel", false ) ) then
 		if ( action == "get" ) then
 			triggerClientEvent ( client, "aModdetails", resourceRoot, "get", getPlayerModInfo(player), player )
 		end
@@ -1582,7 +1582,7 @@ end )
 addEvent ( "aBans", true )
 addEventHandler ( "aBans", root, function ( action, data, arg1, arg2, arg3 )
 	if checkClient( "command."..action, source, 'aBans', action ) then return end
-	if ( hasObjectPermissionTo ( client or source, "command."..action ) ) then
+	if ( hasObjectPermissionTo ( client or source, "command."..action, false ) ) then
 		local mdata = ""
 		local more = ""
 		if ( action == "banip" ) then
@@ -1686,17 +1686,17 @@ function checkClient(checkAccess,player,...)
 	end
 	if checkAccess and g_Prefs.securitylevel >= 1 then
 		if type(checkAccess) == 'string' then
-			if hasObjectPermissionTo ( player, checkAccess ) then
+			if hasObjectPermissionTo ( player, checkAccess, false ) then
 				return false	-- Access ok
 			end
-			if hasObjectPermissionTo ( player, "general.adminpanel" ) then
+			if hasObjectPermissionTo ( player, "general.adminpanel", false ) then
 				local desc = table.concat({...}," ")
 				local ipAddress = getPlayerIP(player)
 				outputDebugString( "Admin security - Client does not have required rights ("..checkAccess.."). " .. tostring(ipAddress) .. " (" .. tostring(desc) .. ")" )
 				return true		-- Low risk fail - Can't do specific command, but has access to admin panel
 			end
 		end
-		if not hasObjectPermissionTo ( player, "general.adminpanel" ) then
+		if not hasObjectPermissionTo ( player, "general.adminpanel", false ) then
 			local desc = table.concat({...}," ")
 			local ipAddress = getPlayerIP(client or player)
 			outputDebugString( "Admin security - Client without admin panel rights trigged an admin panel event. " .. tostring(ipAddress) .. " (" .. tostring(desc) .. ")", 2 )

--- a/[admin]/admin/server/admin_sync.lua
+++ b/[admin]/admin/server/admin_sync.lua
@@ -15,7 +15,7 @@ function aSynchCoroutineFunc( type, data, typeOfTag, banSearchTag )
 	local cor = aSyncCoroutine
 	local tableOut = {}
 	local theSource = root
-	if client and not hasObjectPermissionTo ( client, "general.adminpanel" ) then
+	if client and not hasObjectPermissionTo ( client, "general.adminpanel", false ) then
 		type = "loggedout"
 	elseif ( type == "player" ) then
 		if not isElement( data ) then return end
@@ -51,14 +51,14 @@ function aSynchCoroutineFunc( type, data, typeOfTag, banSearchTag )
 				tableOut[player]["accountname"] = getPlayerAccountName ( player ) or "N/A"
 				tableOut[player]["serial"] = getPlayerSerial ( player )
 				tableOut[player]["country"] = aPlayers[player]["country"]
-				tableOut[player]["admin"] = hasObjectPermissionTo ( player, "general.adminpanel" )
+				tableOut[player]["admin"] = hasObjectPermissionTo ( player, "general.adminpanel", false )
 				tableOut[player]["acdetected"] = getPlayerACDetectedList( player )
 				tableOut[player]["d3d9dll"] = getPlayerD3D9DLLHash( player )
 				tableOut[player]["imgmodsnum"] = getPlayerModCount( player )
 			end
 		end
 	elseif ( type == "resources" ) then
-		if not hasObjectPermissionTo( source, "general.tab_resources" ) then
+		if not hasObjectPermissionTo( source, "general.tab_resources", false ) then
 			return
 		end
 		local resourceTable = getResources()
@@ -100,7 +100,7 @@ function aSynchCoroutineFunc( type, data, typeOfTag, banSearchTag )
 		for id, player in ipairs(getElementsByType("player")) do
 			if isElement(player) and aPlayers[player] then
 				tableOut[player] = {}
-				tableOut[player]["admin"] = hasObjectPermissionTo ( player, "general.adminpanel" )
+				tableOut[player]["admin"] = hasObjectPermissionTo ( player, "general.adminpanel", false )
 				if ( tableOut[player]["admin"] ) then
 					tableOut[player]["chat"] = aPlayers[player]["chat"]
 				end
@@ -281,7 +281,7 @@ end )
 addEvent ( "aPermissions", true )
 addEventHandler ( "aPermissions", root, function()
 	if checkClient( false, source, 'aPermissions' ) then return end
-	if ( hasObjectPermissionTo ( source, "general.adminpanel" ) ) then
+	if ( hasObjectPermissionTo ( source, "general.adminpanel", false ) ) then
 		local tableOut = {}
 		for gi, group in ipairs ( aclGroupList() ) do
 			for oi, object in ipairs ( aclGroupListObjects ( group ) ) do

--- a/[admin]/admin2/server/admin_ACL.lua
+++ b/[admin]/admin2/server/admin_ACL.lua
@@ -256,7 +256,7 @@ local aACLFunctions = {
 addEvent(EVENT_ACL, true)
 addEventHandler(EVENT_ACL, root,
     function(action, ...)
-        if not hasObjectPermissionTo( client, "general.tab_acl" ) then
+        if not hasObjectPermissionTo( client, "general.tab_acl", false ) then
             outputServerLog( ( "[ADMIN SECURITY]: Player %s [%s %s] attempted to tamper with server ACL without proper rights" ):format( client.name, client.ip, client.serial ) )
             return
         end

--- a/[admin]/admin2/server/admin_bans.lua
+++ b/[admin]/admin2/server/admin_bans.lua
@@ -115,7 +115,7 @@ local function handleBanRequest(action, data)
     end
     
     -- Permissions check
-    if not hasObjectPermissionTo(source, "command."..action) then
+    if not hasObjectPermissionTo(source, "command."..action, false) then
         outputChatBox("Access denied for '" .. tostring(action) .. "'", source, 255, 168, 0)
         return
     end

--- a/[admin]/admin2/server/admin_commands.lua
+++ b/[admin]/admin2/server/admin_commands.lua
@@ -55,7 +55,7 @@ function aCommand(admin, command, ...)
     end
     local call = _commands[command]
     if (call) then
-        if (hasObjectPermissionTo(admin, "command." .. call.action)) then
+        if (hasObjectPermissionTo(admin, "command." .. call.action, false)) then
             arg2 = aCommandToArgs({...}, call.args)
             if (call.type == "player") then
                 triggerEvent("aPlayer", admin, arg2[1], call.action, arg2[2], arg2[3])

--- a/[admin]/admin2/server/admin_server.lua
+++ b/[admin]/admin2/server/admin_server.lua
@@ -37,7 +37,7 @@ function aHandleIP2CUpdate()
 
     for playerID = 1, #playersTable do
         local playerElement = playersTable[playerID]
-        local hasAdminPermission = hasObjectPermissionTo(playerElement, "general.adminpanel")
+        local hasAdminPermission = hasObjectPermissionTo(playerElement, "general.adminpanel", false)
 
         if hasAdminPermission then
             
@@ -77,7 +77,7 @@ addEventHandler(
         if (resource ~= getThisResource()) then
             local resourceName = getResourceName(resource)
             for id, player in ipairs(getElementsByType("player")) do
-                if (hasObjectPermissionTo(player, "general.tab_resources")) then
+                if (hasObjectPermissionTo(player, "general.tab_resources", false)) then
                     triggerClientEvent(player, "aClientResourceStart", root, resourceName)
                 end
             end
@@ -104,7 +104,7 @@ addEventHandler(
         if (resource ~= getThisResource()) then
             local resourceName = getResourceName(resource)
             for id, player in ipairs(getElementsByType("player")) do
-                if (hasObjectPermissionTo(player, "general.tab_resources")) then
+                if (hasObjectPermissionTo(player, "general.tab_resources", false)) then
                     triggerClientEvent(player, "aClientResourceStop", root, resourceName)
                 end
             end
@@ -124,7 +124,7 @@ addEventHandler(
     function()
         aPlayerInitialize(source)
         for id, player in ipairs(getElementsByType("player")) do
-            if (hasObjectPermissionTo(player, "general.adminpanel")) then
+            if (hasObjectPermissionTo(player, "general.adminpanel", false)) then
                 triggerClientEvent(
                     player,
                     "aClientPlayerJoin",
@@ -207,7 +207,7 @@ addEventHandler(
     "aTeam",
     root,
     function(action, name, ...)
-        if (hasObjectPermissionTo(client, "command." .. action)) then
+        if (hasObjectPermissionTo(client, "command." .. action, false)) then
             local func = aFunctions.team[action]
             if (func) then
                 local result, mdata1, mdata2 = func(name, ...)
@@ -229,7 +229,7 @@ addEventHandler(
     "aPlayer",
     root,
     function(player, action, ...)
-        if (hasObjectPermissionTo(client, "command." .. action)) then
+        if (hasObjectPermissionTo(client, "command." .. action, false)) then
             local mdata1, mdata2
             local func = aFunctions.player[action]
             if (func) then
@@ -257,7 +257,7 @@ addEventHandler(
         if (not vehicle) then
             return
         end
-        if (hasObjectPermissionTo(client, "command." .. action)) then
+        if (hasObjectPermissionTo(client, "command." .. action, false)) then
             local mdata1, mdata2
             local func = aFunctions.vehicle[action]
             if (func) then
@@ -298,7 +298,7 @@ addEventHandler(
         if (not resource) then
             return
         end
-        if (hasObjectPermissionTo(client, "command." .. action)) then
+        if (hasObjectPermissionTo(client, "command." .. action, false)) then
             local func = aFunctions.resource[action]
             if (func) then
                 local result, mdata1, mdata2 = func(resource, ...)
@@ -320,7 +320,7 @@ addEventHandler(
     "aServer",
     root,
     function(action, ...)
-        if (hasObjectPermissionTo(client, "command." .. action)) then
+        if (hasObjectPermissionTo(client, "command." .. action, false)) then
             local func = aFunctions.server[action]
             if (func) then
                 local result, mdata1, mdata2 = func(...)
@@ -395,7 +395,7 @@ addEventHandler(
             triggerClientEvent(client, "aMessage", client, "get", aReports)
         end
         for id, p in ipairs(getElementsByType("player")) do
-            if (hasObjectPermissionTo(p, "general.adminpanel")) then
+            if (hasObjectPermissionTo(p, "general.adminpanel", false)) then
                 triggerEvent(EVENT_SYNC, p, SYNC_MESSAGES)
             end
         end

--- a/[admin]/admin2/server/admin_session.lua
+++ b/[admin]/admin2/server/admin_session.lua
@@ -12,7 +12,7 @@ local aSessions = {}
 addCommandHandler(
     "adminpanel",
     function(player)
-        if (hasObjectPermissionTo(player, "general.adminpanel")) then
+        if (hasObjectPermissionTo(player, "general.adminpanel", false)) then
             triggerClientEvent(player, "aClientAdminMenu", root)
             aPlayers[player]["chat"] = true
         end
@@ -23,7 +23,7 @@ addEventHandler(
     "onPlayerLogin",
     root,
     function(previous, account, auto)
-        if (hasObjectPermissionTo(source, "general.adminpanel")) then
+        if (hasObjectPermissionTo(source, "general.adminpanel", false)) then
             if (aPlayers[source]["aLoaded"]) then
                 triggerEvent(EVENT_SESSION, source, SESSION_UPDATE)
             end
@@ -42,7 +42,7 @@ addEventHandler(
             end
         end
         if (type == SESSION_UPDATE or type == SESSION_START) then
-            if (hasObjectPermissionTo(client or source, "general.adminpanel")) then
+            if (hasObjectPermissionTo(client or source, "general.adminpanel", false)) then
                 local tableOut = {}
                 local account = "user." .. getAccountName(getPlayerAccount(client or source))
                 for gi, group in ipairs(aclGroupList()) do

--- a/[admin]/admin2/server/admin_sync.lua
+++ b/[admin]/admin2/server/admin_sync.lua
@@ -9,7 +9,7 @@
 **************************************]]
 
 local function hasClientPermissionTo(strRight)
-    if client and not hasObjectPermissionTo(client, strRight) then
+    if client and not hasObjectPermissionTo(client, strRight, false) then
         outputServerLog( ( "[ADMIN SECURITY]: Player %s [%s %s] attempted to perform admin data sync without proper rights (%s)" ):format( client.name, client.ip, client.serial, strRight ) )
         return false
     end
@@ -127,7 +127,7 @@ addEventHandler(
 
             for id, player in ipairs(aPlayers) do
                 tableOut[player] = {}
-                tableOut[player]["admin"] = hasObjectPermissionTo(player, "general.adminpanel")
+                tableOut[player]["admin"] = hasObjectPermissionTo(player, "general.adminpanel", false)
                 if (tableOut[player]["admin"]) then
                     tableOut[player]["chat"] = aPlayers[player]["chat"]
                 end


### PR DESCRIPTION
This PR changes the defaultPermission argument in [hasObjectPermissionTo](https://wiki.multitheftauto.com/wiki/HasObjectPermissionTo) in the admin & admin2 resources from true to false.

This now denies any ACL right that is not explicitly set instead of allowing it, preventing cases where an admin action is missing in `conf/ACL.xml` or when the admin resource fails to create its ACL rights.