### PR TITLE
admin: fix "No map selected" error dialog from appearing incorrectly

### DIFF
--- a/[admin]/admin/client/gui/admin_maps.lua
+++ b/[admin]/admin/client/gui/admin_maps.lua
@@ -65,14 +65,15 @@ function guiClick(button)
 			if source == aTabMap.RefreshList then
 				guiGridListClear(aTabMap.MapList)
 				triggerServerEvent("getMaps_s", localPlayer, true)
+				return
 			end
-			if ( source ~= aTabMap.MapListSearch ) and guiGridListGetSelectedItem ( aTabMap.MapList ) == -1 then
+			local selectedRow = guiGridListGetSelectedItem( aTabMap.MapList )
+			local mapName = guiGridListGetItemText ( aTabMap.MapList, selectedRow, 1 )
+			local mapResName = guiGridListGetItemText ( aTabMap.MapList, selectedRow, 2 )
+			local gamemode = guiGridListGetItemText ( aTabMap.MapList, selectedRow, 3 )
+			if ( source == aTabMap.Start or source == aTabMap.NextMap ) and selectedRow == -1 then
 				aMessageBox ( "error", "No map selected!" )
-			end
-			local mapName = guiGridListGetItemText ( aTabMap.MapList, guiGridListGetSelectedItem( aTabMap.MapList ), 1 )
-			local mapResName = guiGridListGetItemText ( aTabMap.MapList, guiGridListGetSelectedItem( aTabMap.MapList ), 2 )
-			local gamemode = guiGridListGetItemText ( aTabMap.MapList, guiGridListGetSelectedItem( aTabMap.MapList ), 3 )
-			if source == aTabMap.MapList then
+			elseif source == aTabMap.MapList then
 				if gamemode == "race" then
 					guiSetEnabled(aTabMap.NextMap, true)
 				else


### PR DESCRIPTION
This PR makes the "No map selected" error dialog appear only when clicking the "Start Gamemode with Map" or "Set Next Map" buttons. 
Previously, it would appear incorrectly if you clicked other elements in the maps tab, like the gridlist scrollbar or the refresh button, when no map was selected.

Before:

https://github.com/user-attachments/assets/88f5c0d5-cd92-4138-a2c2-9107dd0028fe

After:

https://github.com/user-attachments/assets/f497ea03-9bf6-4d8d-a5de-582932c9f660

