### PR TITLE
race: set vehicle_physics_mode to fixed for the default race maps

### DIFF
--- a/[gamemodes]/[race]/[maps]/race-10laphotring/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-10laphotring/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="240" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-3lapdirtring/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-3lapdirtring/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="270" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-5lap8track/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-5lap8track/meta.xml
@@ -3,5 +3,6 @@
   <map src="5Lap 8track.map" />
   <settings>
     <setting name="#respawn" value="timelimit" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-airportdogfight/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-airportdogfight/meta.xml
@@ -5,5 +5,6 @@
     <setting name="#respawn" value="timelimit" />
     <setting name="#respawntime" value="10" />
     <setting name="#duration" value="450" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-airportspeedway/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-airportspeedway/meta.xml
@@ -5,5 +5,6 @@
     <setting name="#weather" value="4" />
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="240" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-apacheassault/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-apacheassault/meta.xml
@@ -3,5 +3,6 @@
   <map src="Apache Assault.map" />
   <settings>
     <setting name="#respawn" value="none" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-awalkinthepark/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-awalkinthepark/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="250" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-badlandsblastaround/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-badlandsblastaround/meta.xml
@@ -5,5 +5,6 @@
     <setting name="#weather" value="7" />
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="250" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-bandito/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-bandito/meta.xml
@@ -5,5 +5,6 @@
     <setting name="#weather" value="5" />
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="180" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-bayareacircuit/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-bayareacircuit/meta.xml
@@ -7,5 +7,6 @@
     <setting name="#respawn" value="timelimit" />
     <setting name="#respawntime" value="15" />
     <setting name="#duration" value="360" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-bloodring/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-bloodring/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="none" />
     <setting name="#duration" value="360" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-blowthedam/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-blowthedam/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="330" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-boatingblastaround/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-boatingblastaround/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="330" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-bobcatblastaround/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-bobcatblastaround/meta.xml
@@ -5,5 +5,6 @@
     <setting name="#weather" value="6" />
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="250" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-break/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-break/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="none" />
     <setting name="#duration" value="300" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-chiliadclimb/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-chiliadclimb/meta.xml
@@ -3,5 +3,6 @@
   <map src="Chiliad Climb.map" />
   <settings>
     <setting name="#respawn" value="timelimit" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-chrmleasy/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-chrmleasy/meta.xml
@@ -5,5 +5,6 @@
     <setting name="#weather" value="8" />
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="450" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-chrmlhard/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-chrmlhard/meta.xml
@@ -5,5 +5,6 @@
     <setting name="#weather" value="4" />
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="450" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-degenerationofx/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-degenerationofx/meta.xml
@@ -5,5 +5,6 @@
     <setting name="#time" value="4:0" />
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="780" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-desertdogfight/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-desertdogfight/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="none" />
     <setting name="#duration" value="360" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-destructionderby/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-destructionderby/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="270" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-dockbikes/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-dockbikes/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="300" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-docksideblastaround/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-docksideblastaround/meta.xml
@@ -5,5 +5,6 @@
     <setting name="#weather" value="1" />
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="300" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-drift/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-drift/meta.xml
@@ -5,5 +5,6 @@
     <setting name="#weather" value="5" />
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="240" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-driftcity/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-driftcity/meta.xml
@@ -7,6 +7,7 @@
       <setting name="#respawntime" value="7"/>
       <setting name="#weather" value="10"/>
       <setting name="#respawn" value="timelimit"/>
+      <setting name="#vehicle_physics_mode" value="fixed" />
    </settings>
 </meta>
 

--- a/[gamemodes]/[race]/[maps]/race-dunebuggy/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-dunebuggy/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="360" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-errand/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-errand/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="250" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-farewellmylove/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-farewellmylove/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="330" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-farm2city/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-farm2city/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="240" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-findthecock/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-findthecock/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="300" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-freeroam/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-freeroam/meta.xml
@@ -5,5 +5,6 @@
     <setting name="#respawn" value="timelimit" />
     <setting name="#respawntime" value="12" />
     <setting name="#duration" value="600" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-highnoon/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-highnoon/meta.xml
@@ -5,5 +5,6 @@
     <setting name="#time" value="21:0" />
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="210" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-homeinthehills/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-homeinthehills/meta.xml
@@ -5,5 +5,6 @@
     <setting name="#weather" value="3" />
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="270" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-hotroute/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-hotroute/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="660" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-hydrarace/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-hydrarace/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="600" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-island/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-island/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="450" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-justanotherbikerace/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-justanotherbikerace/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="270" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-longwayround/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-longwayround/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="780" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-lsairport/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-lsairport/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="360" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-lstrenches/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-lstrenches/meta.xml
@@ -6,5 +6,6 @@
     <setting name="#weather" value="2" />
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="360" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-lvsprint/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-lvsprint/meta.xml
@@ -7,5 +7,6 @@
     <setting name="#respawn" value="timelimit" />
     <setting name="#respawntime" value="20" />
     <setting name="#duration" value="240" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-midairmayhem/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-midairmayhem/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="180" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-miniputt/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-miniputt/meta.xml
@@ -6,5 +6,6 @@
     <setting name="#weather" value="5" />
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="480" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-monsterblastaround/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-monsterblastaround/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="360" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-mx_sky/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-mx_sky/meta.xml
@@ -6,5 +6,6 @@
     <setting name="#weather" value="6" />
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="300" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-offroadblastaround/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-offroadblastaround/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="360" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-predatorzone/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-predatorzone/meta.xml
@@ -7,5 +7,6 @@
     <setting name="#respawn" value="timelimit" />
     <setting name="#respawntime" value="10" />
     <setting name="#duration" value="300" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-quarryrun/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-quarryrun/meta.xml
@@ -6,5 +6,6 @@
     <setting name="#weather" value="3" />
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="300" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-rcairwar/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-rcairwar/meta.xml
@@ -7,5 +7,6 @@
     <setting name="#respawn" value="timelimit" />
     <setting name="#respawntime" value="10" />
     <setting name="#duration" value="300" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-rcwarz/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-rcwarz/meta.xml
@@ -5,5 +5,6 @@
     <setting name="#respawn" value="timelimit" />
     <setting name="#respawntime" value="6" />
     <setting name="#duration" value="360" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-runway69/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-runway69/meta.xml
@@ -6,5 +6,6 @@
     <setting name="#weather" value="9" />
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="360" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-rustlerrampage/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-rustlerrampage/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="420" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-sandking/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-sandking/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="240" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-santosdrive/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-santosdrive/meta.xml
@@ -7,5 +7,6 @@
     <setting name="#respawn" value="timelimit" />
     <setting name="#respawntime" value="6" />
     <setting name="#duration" value="360" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-seadragon/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-seadragon/meta.xml
@@ -6,5 +6,6 @@
     <setting name="#weather" value="8" />
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="520" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-seahunter/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-seahunter/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="none" />
     <setting name="#duration" value="780" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-searustler/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-searustler/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="none" />
     <setting name="#duration" value="780" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-sewers/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-sewers/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="240" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-sfbynight/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-sfbynight/meta.xml
@@ -7,5 +7,6 @@
     <setting name="#respawn" value="timelimit" />
     <setting name="#respawntime" value="20" />
     <setting name="#duration" value="360" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-smugglersrun/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-smugglersrun/meta.xml
@@ -7,5 +7,6 @@
     <setting name="#respawn" value="timelimit" />
     <setting name="#respawntime" value="20" />
     <setting name="#duration" value="600" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-sparrowstorm/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-sparrowstorm/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="none" />
     <setting name="#duration" value="420" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-specialdelivery/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-specialdelivery/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="270" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-speedforweed/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-speedforweed/meta.xml
@@ -7,6 +7,7 @@
       <setting name="#respawntime" value="7"/>
       <setting name="#weather" value="10"/>
       <setting name="#respawn" value="timelimit"/>
+      <setting name="#vehicle_physics_mode" value="fixed" />
    </settings>
 </meta>
 

--- a/[gamemodes]/[race]/[maps]/race-squalorace/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-squalorace/meta.xml
@@ -6,5 +6,6 @@
     <setting name="#respawn" value="timelimit" />
     <setting name="#respawntime" value="20" />
     <setting name="#duration" value="300" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-stunt/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-stunt/meta.xml
@@ -3,5 +3,6 @@
   <map src="Stunt.map" />
   <settings>
     <setting name="#respawn" value="timelimit" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-suburbanspeedway/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-suburbanspeedway/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="200" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-superhydrarace/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-superhydrarace/meta.xml
@@ -5,5 +5,6 @@
     <setting name="#weather" value="8" />
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="600" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-technicalitch/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-technicalitch/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="360" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-thepanopticon/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-thepanopticon/meta.xml
@@ -5,5 +5,6 @@
     <setting name="#time" value="1:0" />
     <setting name="#weather" value="8" />
     <setting name="#respawn" value="timelimit" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-vinewoodblastaround/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-vinewoodblastaround/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="330" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>

--- a/[gamemodes]/[race]/[maps]/race-wuzimu/meta.xml
+++ b/[gamemodes]/[race]/[maps]/race-wuzimu/meta.xml
@@ -4,5 +4,6 @@
   <settings>
     <setting name="#respawn" value="timelimit" />
     <setting name="#duration" value="360" />
+    <setting name="#vehicle_physics_mode" value="fixed" />
   </settings>
 </meta>


### PR DESCRIPTION
This PR updates all default race maps to use the `fixed` physics mode.