### PR TITLE
editor_main: respawn player on death

### DIFF
--- a/[editor]/editor_main/client/playerspawn.lua
+++ b/[editor]/editor_main/client/playerspawn.lua
@@ -1,0 +1,7 @@
+addEventHandler("onClientPlayerSpawn",localPlayer,
+    function()
+        if not getElementData(resourceRoot, "g_in_test") then
+            setElementInterior(localPlayer, getWorkingInterior())
+        end
+    end
+)

--- a/[editor]/editor_main/meta.xml
+++ b/[editor]/editor_main/meta.xml
@@ -66,6 +66,7 @@
 	<!-- Player attachment and spawning -->
 	<script src="client/superman.lua" type="client" validate="false" />
 	<script src="client/attachplayer.lua" type="client" validate="false" />
+	<script src="client/playerspawn.lua" type="client" />
 	<script src="server/playerspawn.lua" type="server" />
 	<script src="server/playerblips.lua" type="server" />
 

--- a/[editor]/editor_main/server/playerspawn.lua
+++ b/[editor]/editor_main/server/playerspawn.lua
@@ -18,6 +18,16 @@ addEventHandler ( "onPlayerJoin", root,
 	end
 )
 
+addEventHandler ( "onPlayerWasted", root,
+	function()
+		if not g_in_test then
+			local x,y,z = getElementPosition(source)
+			local rx,ry,rz = getElementRotation(source)
+			spawnPlayer ( source, x, y, z, rz, 0, 0, getWorkingDimension() )
+		end
+	end
+)
+
 function disablePickups(bool)
 	if bool and not pickupsDisabled then
 		pickupsDisabled = true


### PR DESCRIPTION
Closes #651.

This PR makes players respawn instantly on death. This only works while the player is in the editor or during a basic test (F6). If a full test is running, it won't respawn the player, so it doesn't conflict with the running gamemode.