### PR TITLE
Fix missing definitions prevent EDF element from loading

### DIFF
--- a/[gamemodes]/[briefcaserace]/[maps]/br-sf-autoteams/briefcaserace-sf.map
+++ b/[gamemodes]/[briefcaserace]/[maps]/br-sf-autoteams/briefcaserace-sf.map
@@ -1,4 +1,4 @@
-<map>
+﻿<map edf:definitions="briefcaserace">
 
    <vehicle id="Sentinel" model="405" posX="-1988.01171875" posY="128.8193359375" posZ="27.413967132568" rotX="0" rotY="359.99450683594" rotZ="1.7303466796875" />
    <vehicle id="Blista Compact" model="496" posX="-1987.8955078125" posY="119.84765625" posZ="27.255165100098" rotX="0.0439453125" rotY="359.99450683594" rotZ="0.1702880859375" />

--- a/[gamemodes]/[briefcaserace]/[maps]/br-sf-teams/briefcaserace-sf.map
+++ b/[gamemodes]/[briefcaserace]/[maps]/br-sf-teams/briefcaserace-sf.map
@@ -1,4 +1,4 @@
-<map>
+﻿<map edf:definitions="briefcaserace">
 
   <team name="Hippies" color="#ff7f50" />
   <team name="Suits" color="#6495ed" />

--- a/[gamemodes]/[briefcaserace]/[maps]/br-sf/briefcaserace-sf.map
+++ b/[gamemodes]/[briefcaserace]/[maps]/br-sf/briefcaserace-sf.map
@@ -1,4 +1,4 @@
-<map>
+﻿<map edf:definitions="briefcaserace">
 
   <spawnpoint id="spawnpoint_1" posX="-1982.86" posY="112.54" posZ="27.68" rot="0" skin="60"/>
   <spawnpoint id="spawnpoint_1" posX="-2035.7490234375" posY="139.54206848145" posZ="28.8359375" rot="270" skin="170"/>

--- a/[gamemodes]/[deathmatch]/[maps]/dm-port69/port69.map
+++ b/[gamemodes]/[deathmatch]/[maps]/dm-port69/port69.map
@@ -1,4 +1,4 @@
-<map edf:definitions="editor_main">
+<map edf:definitions="deathmatch,editor_main">
     <spawnpoint id="spawnpoint (1)" interior="0" skin="0" dimension="0" posX="-1517.5894775391" posY="108.93153381348" posZ="17.328125" rotX="0" rotY="0" rotZ="117.11505126953" />
     <spawnpoint id="spawnpoint (2)" interior="0" skin="7" dimension="0" posX="-1697.6484375" posY="76.0380859375" posZ="4.0494818687439" rotX="0" rotY="0" rotZ="270.67498779297" />
     <spawnpoint id="spawnpoint (3)" interior="0" skin="27" dimension="0" posX="-1682.0185546875" posY="-112.748046875" posZ="4.0546860694885" rotX="0" rotY="0" rotZ="0" />

--- a/[gamemodes]/[race]/[maps]/race-10laphotring/10Lap Hotring.map
+++ b/[gamemodes]/[race]/[maps]/race-10laphotring/10Lap Hotring.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-1354.557861" posY="1080.005005" posZ="1039.676392" rotation="80" vehicle="502" id="spawnpoint0" />
   <spawnpoint posX="-1355.963867" posY="1085.023560" posZ="1039.940186" rotation="80" vehicle="502" id="spawnpoint1" />
   <spawnpoint posX="-1353.029297" posY="1074.870605" posZ="1039.435181" rotation="80" vehicle="502" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-3lapdirtring/3Lap Dirtring.map
+++ b/[gamemodes]/[race]/[maps]/race-3lapdirtring/3Lap Dirtring.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-1404.566650" posY="-593.657715" posZ="1059.458008" rotation="85" vehicle="468" id="spawnpoint0" />
   <spawnpoint posX="-1408.259155" posY="-588.916565" posZ="1058.217407" rotation="85" vehicle="468" id="spawnpoint1" />
   <spawnpoint posX="-1410.240112" posY="-585.756958" posZ="1057.612427" rotation="85" vehicle="468" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-5lap8track/5Lap 8track.map
+++ b/[gamemodes]/[race]/[maps]/race-5lap8track/5Lap 8track.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-1398.503784" posY="-236.526550" posZ="1043.057007" rotation="360" vehicle="502" id="spawnpoint0" />
   <spawnpoint posX="-1392.988647" posY="-234.726913" posZ="1043.060547" rotation="360" vehicle="502" id="spawnpoint1" />
   <spawnpoint posX="-1393.071289" posY="-227.720947" posZ="1042.996704" rotation="360" vehicle="502" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-airportdogfight/Airport Dogfight.map
+++ b/[gamemodes]/[race]/[maps]/race-airportdogfight/Airport Dogfight.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-1287.132813" posY="-628.558533" posZ="14.048437" rotation="360" vehicle="475" id="spawnpoint0" />
   <spawnpoint posX="-1291.459229" posY="-628.733398" posZ="14.048437" rotation="360" vehicle="475" id="spawnpoint1" />
   <spawnpoint posX="-1297.378784" posY="-628.194336" posZ="14.048437" rotation="360" vehicle="475" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-airportspeedway/Airport Speedway.map
+++ b/[gamemodes]/[race]/[maps]/race-airportspeedway/Airport Speedway.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="1527.832275" posY="-2126.095703" posZ="13.895068" rotation="98" vehicle="461" id="spawnpoint0" />
   <spawnpoint posX="1528.831787" posY="-2127.435059" posZ="13.909611" rotation="98" vehicle="461" id="spawnpoint1" />
   <spawnpoint posX="1529.860352" posY="-2128.730225" posZ="13.924838" rotation="98" vehicle="461" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-apacheassault/Apache Assault.map
+++ b/[gamemodes]/[race]/[maps]/race-apacheassault/Apache Assault.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="135.191223" posY="1927.361816" posZ="19.870682" rotation="360" vehicle="425" id="spawnpoint0" />
   <spawnpoint posX="273.504608" posY="1989.381470" posZ="27.323740" rotation="90" vehicle="425" id="spawnpoint1" />
   <spawnpoint posX="136.861115" posY="1875.639771" posZ="23.288500" rotation="182" vehicle="425" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-awalkinthepark/A Walk in the Park.map
+++ b/[gamemodes]/[race]/[maps]/race-awalkinthepark/A Walk in the Park.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="1175.756958" posY="-2006.232666" posZ="68.668190" rotation="271" vehicle="461" id="spawnpoint0" />
   <spawnpoint posX="1175.802490" posY="-2009.735352" posZ="68.660988" rotation="271" vehicle="461" id="spawnpoint1" />
   <spawnpoint posX="1176.004883" posY="-2026.066895" posZ="68.660988" rotation="271" vehicle="461" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-badlandsblastaround/BADlands BLASTAround.map
+++ b/[gamemodes]/[race]/[maps]/race-badlandsblastaround/BADlands BLASTAround.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-1013.399414" posY="-674.968323" posZ="31.757813" rotation="360" vehicle="429" id="spawnpoint0" />
   <spawnpoint posX="-1016.562744" posY="-675.233093" posZ="31.757813" rotation="360" vehicle="429" id="spawnpoint1" />
   <spawnpoint posX="-1019.442505" posY="-675.876953" posZ="31.757813" rotation="360" vehicle="429" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-bandito/Bandito.map
+++ b/[gamemodes]/[race]/[maps]/race-bandito/Bandito.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="647.545898" posY="-86.226227" posZ="18.154303" rotation="314" vehicle="568" id="spawnpoint0" />
   <spawnpoint posX="644.255981" posY="-84.507111" posZ="17.854946" rotation="299" vehicle="568" id="spawnpoint1" />
   <spawnpoint posX="643.006287" posY="-80.327805" posZ="16.692375" rotation="304" vehicle="568" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-bayareacircuit/Bay Area Circuit.map
+++ b/[gamemodes]/[race]/[maps]/race-bayareacircuit/Bay Area Circuit.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-2256.867188" posY="2286.105957" posZ="4.480591" rotation="360" vehicle="521" id="spawnpoint0" />
   <spawnpoint posX="-2259.417969" posY="2286.005615" posZ="4.480591" rotation="360" vehicle="521" id="spawnpoint1" />
   <spawnpoint posX="-2266.610840" posY="2285.940430" posZ="4.480591" rotation="360" vehicle="521" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-bloodring/Bloodring.map
+++ b/[gamemodes]/[race]/[maps]/race-bloodring/Bloodring.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-1351.286133" posY="938.433289" posZ="1036.362183" rotation="7" vehicle="504" id="spawnpoint0" />
   <spawnpoint posX="-1481.112183" posY="1039.506348" posZ="1038.262451" rotation="211" vehicle="504" id="spawnpoint1" />
   <spawnpoint posX="-1493.101196" posY="1031.263428" posZ="1038.152954" rotation="223" vehicle="504" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-blowthedam/Blow the Dam.map
+++ b/[gamemodes]/[race]/[maps]/race-blowthedam/Blow the Dam.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="1547.594849" posY="-2086.397705" posZ="822.643127" rotation="360" vehicle="581" id="spawnpoint0" />
   <spawnpoint posX="1545.912964" posY="-2086.417725" posZ="822.633789" rotation="360" vehicle="581" id="spawnpoint1" />
   <spawnpoint posX="1543.630371" posY="-2086.344482" posZ="822.626526" rotation="360" vehicle="581" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-boatingblastaround/Boating BLASTAround.map
+++ b/[gamemodes]/[race]/[maps]/race-boatingblastaround/Boating BLASTAround.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="73.360115" posY="-1994.152954" posZ="0.796879" rotation="360" vehicle="446" id="spawnpoint0" />
   <spawnpoint posX="78.360115" posY="-1994.303101" posZ="0.796879" rotation="360" vehicle="446" id="spawnpoint1" />
   <spawnpoint posX="68.310112" posY="-1994.203003" posZ="0.046879" rotation="360" vehicle="446" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-bobcatblastaround/Bobcat BLASTAround.map
+++ b/[gamemodes]/[race]/[maps]/race-bobcatblastaround/Bobcat BLASTAround.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-1295.084106" posY="2706.965088" posZ="50.142502" rotation="161" vehicle="422" id="spawnpoint0" />
   <spawnpoint posX="-1303.214478" posY="2709.637695" posZ="50.142502" rotation="158" vehicle="422" id="spawnpoint1" />
   <spawnpoint posX="-1294.341431" posY="2699.922119" posZ="50.142494" rotation="161" vehicle="422" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-break/Break.map
+++ b/[gamemodes]/[race]/[maps]/race-break/Break.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="2392.000000" posY="-4072.000000" posZ="3.353250" rotation="360" vehicle="424" id="spawnpoint0" />
   <spawnpoint posX="2388.000000" posY="-4028.000000" posZ="3.353250" rotation="179" vehicle="424" id="spawnpoint1" />
   <spawnpoint posX="2368.000000" posY="-4052.000000" posZ="3.353250" rotation="270" vehicle="424" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-chiliadclimb/Chiliad Climb.map
+++ b/[gamemodes]/[race]/[maps]/race-chiliadclimb/Chiliad Climb.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-2389.578125" posY="-2214.670410" posZ="32.949440" rotation="339" vehicle="468" id="spawnpoint0" />
   <spawnpoint posX="-2392.252930" posY="-2214.180420" posZ="32.949440" rotation="330" vehicle="468" id="spawnpoint1" />
   <spawnpoint posX="-2394.579834" posY="-2212.746582" posZ="32.949440" rotation="320" vehicle="468" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-chrmleasy/ChrML Easy.map
+++ b/[gamemodes]/[race]/[maps]/race-chrmleasy/ChrML Easy.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="412.912231" posY="2487.052246" posZ="17.403950" rotation="90" vehicle="520" id="spawnpoint0" />
   <spawnpoint posX="419.902344" posY="2520.104248" posZ="17.403950" rotation="89" vehicle="520" id="spawnpoint1" />
   <spawnpoint posX="369.443146" posY="2462.106201" posZ="17.403950" rotation="85" vehicle="520" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-chrmlhard/ChrML Hard.map
+++ b/[gamemodes]/[race]/[maps]/race-chrmlhard/ChrML Hard.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="2323.428467" posY="-768.621094" posZ="130.810791" rotation="65" vehicle="520" id="spawnpoint0" />
   <spawnpoint posX="2315.108154" posY="-781.371948" posZ="129.605301" rotation="55" vehicle="520" id="spawnpoint1" />
   <spawnpoint posX="2305.642090" posY="-794.385559" posZ="129.064407" rotation="55" vehicle="520" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-degenerationofx/Degeneration Of X.map
+++ b/[gamemodes]/[race]/[maps]/race-degenerationofx/Degeneration Of X.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="6358.939941" posY="-575.068420" posZ="16.530289" rotation="178" vehicle="520" id="spawnpoint0" />
   <spawnpoint posX="6242.269531" posY="-558.894653" posZ="16.555288" rotation="360" vehicle="520" id="spawnpoint1" />
   <spawnpoint posX="6231.683105" posY="-558.917114" posZ="16.530289" rotation="360" vehicle="520" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-desertdogfight/Desert Dogfight.map
+++ b/[gamemodes]/[race]/[maps]/race-desertdogfight/Desert Dogfight.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="36.842506" posY="2266.003906" posZ="124.454262" rotation="352" vehicle="520" id="spawnpoint0" />
   <spawnpoint posX="97.457504" posY="2239.397705" posZ="125.632393" rotation="276" vehicle="520" id="spawnpoint1" />
   <spawnpoint posX="33.762665" posY="2225.252197" posZ="126.073143" rotation="178" vehicle="520" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-destructionderby/Destruction Derby.map
+++ b/[gamemodes]/[race]/[maps]/race-destructionderby/Destruction Derby.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="574.966553" posY="3530.391602" posZ="759.616943" rotation="41" vehicle="518" id="spawnpoint0" />
   <spawnpoint posX="503.239105" posY="3496.731445" posZ="759.616943" rotation="41" vehicle="518" id="spawnpoint1" />
   <spawnpoint posX="521.274475" posY="3593.994141" posZ="762.135742" rotation="41" vehicle="518" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-dockbikes/Dock Bikes.map
+++ b/[gamemodes]/[race]/[maps]/race-dockbikes/Dock Bikes.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="1923.078125" posY="-2698.239014" posZ="13.237566" rotation="270" vehicle="510" id="spawnpoint0" />
   <spawnpoint posX="1923.078125" posY="-2699.239014" posZ="13.237565" rotation="270" vehicle="510" id="spawnpoint1" />
   <spawnpoint posX="1923.078125" posY="-2700.239014" posZ="13.242717" rotation="270" vehicle="510" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-docksideblastaround/Dockside BLASTAround.map
+++ b/[gamemodes]/[race]/[maps]/race-docksideblastaround/Dockside BLASTAround.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-1630.291138" posY="-285.875671" posZ="13.804342" rotation="324" vehicle="522" id="spawnpoint0" />
   <spawnpoint posX="-1631.403076" posY="-285.359650" posZ="13.804341" rotation="324" vehicle="522" id="spawnpoint1" />
   <spawnpoint posX="-1632.635864" posY="-284.600311" posZ="13.804342" rotation="324" vehicle="522" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-drift/Drift.map
+++ b/[gamemodes]/[race]/[maps]/race-drift/Drift.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="2591.249023" posY="-2237.008301" posZ="13.541852" rotation="90" vehicle="603" id="spawnpoint0" />
   <spawnpoint posX="2591.376465" posY="-2233.908691" posZ="13.549550" rotation="90" vehicle="603" id="spawnpoint1" />
   <spawnpoint posX="2591.009521" posY="-2230.881348" posZ="13.361640" rotation="90" vehicle="603" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-driftcity/KWK DRIFT CITY.map
+++ b/[gamemodes]/[race]/[maps]/race-driftcity/KWK DRIFT CITY.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-1036.736206" posY="1014.367920" posZ="2.794063" rotation="216" vehicle="411" id="spawnpoint0" />
   <spawnpoint posX="-1039.481689" posY="1012.539917" posZ="2.794063" rotation="216" vehicle="411" id="spawnpoint1" />
   <spawnpoint posX="-1033.779175" posY="1016.272949" posZ="2.794063" rotation="216" vehicle="411" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-dunebuggy/Dune Buggy.map
+++ b/[gamemodes]/[race]/[maps]/race-dunebuggy/Dune Buggy.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-54.375320" posY="857.336426" posZ="17.751417" rotation="25" vehicle="568" id="spawnpoint0" />
   <spawnpoint posX="-49.670555" posY="859.739380" posZ="17.730494" rotation="25" vehicle="568" id="spawnpoint1" />
   <spawnpoint posX="-45.029732" posY="862.293030" posZ="17.904444" rotation="25" vehicle="568" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-errand/Errand.map
+++ b/[gamemodes]/[race]/[maps]/race-errand/Errand.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="2282.652832" posY="-1146.428223" posZ="26.552389" rotation="178" vehicle="429" id="spawnpoint0" />
   <spawnpoint posX="2285.602051" posY="-1146.428223" posZ="26.552389" rotation="178" vehicle="429" id="spawnpoint1" />
   <spawnpoint posX="2288.627930" posY="-1146.428223" posZ="26.552389" rotation="178" vehicle="429" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-farewellmylove/Farewell My Love.map
+++ b/[gamemodes]/[race]/[maps]/race-farewellmylove/Farewell My Love.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-535.735840" posY="-193.285095" posZ="78.186348" rotation="90" vehicle="560" id="spawnpoint0" />
   <spawnpoint posX="-535.718994" posY="-190.841812" posZ="78.186348" rotation="90" vehicle="560" id="spawnpoint1" />
   <spawnpoint posX="-535.743713" posY="-188.406738" posZ="78.186348" rotation="90" vehicle="560" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-farm2city/Farm2City.map
+++ b/[gamemodes]/[race]/[maps]/race-farm2city/Farm2City.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="987.426514" posY="-621.530334" posZ="120.204422" rotation="345" vehicle="581" id="spawnpoint0" />
   <spawnpoint posX="988.426514" posY="-621.530334" posZ="120.204422" rotation="345" vehicle="581" id="spawnpoint1" />
   <spawnpoint posX="989.426514" posY="-621.530334" posZ="120.204422" rotation="345" vehicle="581" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-findthecock/Find the Cock.map
+++ b/[gamemodes]/[race]/[maps]/race-findthecock/Find the Cock.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="151.831482" posY="1362.633545" posZ="10.143716" rotation="360" vehicle="468" id="spawnpoint0" />
   <spawnpoint posX="151.717621" posY="1359.812500" posZ="10.345939" rotation="360" vehicle="468" id="spawnpoint1" />
   <spawnpoint posX="149.140411" posY="1362.972778" posZ="10.345937" rotation="360" vehicle="468" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-freeroam/Freeroam.map
+++ b/[gamemodes]/[race]/[maps]/race-freeroam/Freeroam.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-2545.233154" posY="-2367.946045" posZ="14.972599" rotation="194" vehicle="522" id="spawnpoint0" />
   <spawnpoint posX="-2589.878906" posY="-2409.917236" posZ="18.820740" rotation="194" vehicle="522" id="spawnpoint1" />
   <spawnpoint posX="-2605.929443" posY="-2264.186035" posZ="18.038595" rotation="194" vehicle="522" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-highnoon/High Noon.map
+++ b/[gamemodes]/[race]/[maps]/race-highnoon/High Noon.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-391.109497" posY="2246.139404" posZ="42.472828" rotation="12" vehicle="470" id="spawnpoint0" />
   <spawnpoint posX="-388.209534" posY="2246.844482" posZ="42.472828" rotation="12" vehicle="470" id="spawnpoint1" />
   <spawnpoint posX="-385.159729" posY="2247.673096" posZ="42.472828" rotation="12" vehicle="470" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-homeinthehills/Home in the Hills.map
+++ b/[gamemodes]/[race]/[maps]/race-homeinthehills/Home in the Hills.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="1275.756226" posY="-723.848877" posZ="93.373528" rotation="112" vehicle="555" id="spawnpoint0" />
   <spawnpoint posX="1273.961304" posY="-718.924377" posZ="93.374062" rotation="112" vehicle="555" id="spawnpoint1" />
   <spawnpoint posX="1269.444336" posY="-723.739929" posZ="93.552422" rotation="112" vehicle="555" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-hotroute/Hot Route.map
+++ b/[gamemodes]/[race]/[maps]/race-hotroute/Hot Route.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="2483.892334" posY="2785.124512" posZ="10.480690" rotation="132" vehicle="522" id="spawnpoint0" />
   <spawnpoint posX="2483.892334" posY="2786.624512" posZ="10.480690" rotation="132" vehicle="522" id="spawnpoint1" />
   <spawnpoint posX="2483.892334" posY="2788.124512" posZ="10.480690" rotation="132" vehicle="522" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-hydrarace/Hydra Race.map
+++ b/[gamemodes]/[race]/[maps]/race-hydrarace/Hydra Race.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="436.650116" posY="2522.341064" posZ="17.788849" rotation="92" vehicle="520" id="spawnpoint0" />
   <spawnpoint posX="437.269745" posY="2504.496338" posZ="17.711937" rotation="92" vehicle="520" id="spawnpoint1" />
   <spawnpoint posX="437.592468" posY="2486.112305" posZ="17.783958" rotation="85" vehicle="520" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-island/Island.map
+++ b/[gamemodes]/[race]/[maps]/race-island/Island.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-2232.534668" posY="1886.102905" posZ="30.852552" rotation="360" vehicle="402" id="spawnpoint0" />
   <spawnpoint posX="-2485.109375" posY="1855.475708" posZ="1.565301" rotation="352" vehicle="402" id="spawnpoint1" />
   <spawnpoint posX="-2463.678467" posY="1989.913086" posZ="15.321385" rotation="276" vehicle="402" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-justanotherbikerace/Just Another Bike Race.map
+++ b/[gamemodes]/[race]/[maps]/race-justanotherbikerace/Just Another Bike Race.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-1386.025391" posY="1934.137451" posZ="50.444504" rotation="80" vehicle="468" id="spawnpoint0" />
   <spawnpoint posX="-1385.767456" posY="1935.084473" posZ="50.472397" rotation="80" vehicle="468" id="spawnpoint1" />
   <spawnpoint posX="-1385.571167" posY="1936.007935" posZ="50.400410" rotation="80" vehicle="468" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-longwayround/Long Way Round.map
+++ b/[gamemodes]/[race]/[maps]/race-longwayround/Long Way Round.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="2297.946045" posY="-2204.122314" posZ="5.762500" rotation="46" vehicle="541" id="spawnpoint0" />
   <spawnpoint posX="2301.946045" posY="-2204.122314" posZ="5.762500" rotation="46" vehicle="541" id="spawnpoint1" />
   <spawnpoint posX="2305.696045" posY="-2204.122314" posZ="5.762500" rotation="46" vehicle="541" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-lsairport/LS Airport.map
+++ b/[gamemodes]/[race]/[maps]/race-lsairport/LS Airport.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="1979.603760" posY="-1752.355835" posZ="13.246875" rotation="89" vehicle="541" id="spawnpoint0" />
   <spawnpoint posX="1979.853760" posY="-1748.855835" posZ="13.246875" rotation="89" vehicle="541" id="spawnpoint1" />
   <spawnpoint posX="1979.353760" posY="-1755.855835" posZ="13.246875" rotation="89" vehicle="541" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-lstrenches/LS Trenches.map
+++ b/[gamemodes]/[race]/[maps]/race-lstrenches/LS Trenches.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="2560.655029" posY="-2207.602783" posZ="-0.558373" rotation="360" vehicle="463" id="spawnpoint0" />
   <spawnpoint posX="2561.887451" posY="-2207.377197" posZ="-0.558373" rotation="360" vehicle="463" id="spawnpoint1" />
   <spawnpoint posX="2563.182373" posY="-2207.531006" posZ="-0.558373" rotation="360" vehicle="463" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-lvsprint/LV Sprint.map
+++ b/[gamemodes]/[race]/[maps]/race-lvsprint/LV Sprint.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="2056.865479" posY="800.116211" posZ="10.494814" rotation="360" vehicle="462" id="spawnpoint0" />
   <spawnpoint posX="2060.315918" posY="800.071289" posZ="10.494814" rotation="360" vehicle="462" id="spawnpoint1" />
   <spawnpoint posX="2053.486084" posY="800.246216" posZ="10.494814" rotation="360" vehicle="462" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-midairmayhem/MidAir Mayhem.map
+++ b/[gamemodes]/[race]/[maps]/race-midairmayhem/MidAir Mayhem.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="2962.559326" posY="-2996.453857" posZ="64.682053" rotation="281" vehicle="541" id="spawnpoint0" />
   <spawnpoint posX="2961.036133" posY="-2993.162598" posZ="64.682053" rotation="281" vehicle="541" id="spawnpoint1" />
   <spawnpoint posX="2958.625488" posY="-2989.945068" posZ="64.682053" rotation="281" vehicle="541" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-miniputt/Miniputt.map
+++ b/[gamemodes]/[race]/[maps]/race-miniputt/Miniputt.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="287.720184" posY="-5328.431152" posZ="36.097065" rotation="270" vehicle="432" id="spawnpoint0" />
   <spawnpoint posX="287.836334" posY="-5336.289063" posZ="36.097065" rotation="270" vehicle="432" id="spawnpoint1" />
   <spawnpoint posX="301.545624" posY="-5336.811523" posZ="36.097065" rotation="270" vehicle="432" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-monsterblastaround/Monster BLASTAround.map
+++ b/[gamemodes]/[race]/[maps]/race-monsterblastaround/Monster BLASTAround.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-294.494690" posY="1544.541626" posZ="75.751122" rotation="166" vehicle="444" id="spawnpoint0" />
   <spawnpoint posX="-290.663818" posY="1543.481079" posZ="75.751122" rotation="166" vehicle="444" id="spawnpoint1" />
   <spawnpoint posX="-286.638824" posY="1542.456543" posZ="75.751122" rotation="166" vehicle="444" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-mx_sky/mx_sky.map
+++ b/[gamemodes]/[race]/[maps]/race-mx_sky/mx_sky.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-2429.197510" posY="-331.022186" posZ="329.353302" vehicle="521" id="spawnpoint0" />
   <spawnpoint posX="-2429.890869" posY="-324.965393" posZ="329.323914" vehicle="521" id="spawnpoint1" />
   <spawnpoint posX="-2424.764648" posY="-330.850037" posZ="329.323914" vehicle="521" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-offroadblastaround/Offroad BLASTAround.map
+++ b/[gamemodes]/[race]/[maps]/race-offroadblastaround/Offroad BLASTAround.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-2366.189697" posY="-2318.107910" posZ="20.690945" rotation="79" vehicle="471" id="spawnpoint0" />
   <spawnpoint posX="-2365.836426" posY="-2316.269287" posZ="20.741489" rotation="79" vehicle="471" id="spawnpoint1" />
   <spawnpoint posX="-2365.800049" posY="-2314.385986" posZ="20.566967" rotation="79" vehicle="471" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-predatorzone/Predator Zone.map
+++ b/[gamemodes]/[race]/[maps]/race-predatorzone/Predator Zone.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="3413.541016" posY="463.980804" posZ="0.562383" rotation="90" vehicle="430" id="spawnpoint0" />
   <spawnpoint posX="2941.802734" posY="465.534851" posZ="0.562383" rotation="270" vehicle="430" id="spawnpoint1" />
   <spawnpoint posX="3193.115967" posY="689.606689" posZ="0.562383" rotation="181" vehicle="430" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-quarryrun/Quarry Run.map
+++ b/[gamemodes]/[race]/[maps]/race-quarryrun/Quarry Run.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="826.206299" posY="856.096802" posZ="11.870696" rotation="113" vehicle="468" id="spawnpoint0" />
   <spawnpoint posX="830.561951" posY="845.619751" posZ="11.400368" rotation="113" vehicle="468" id="spawnpoint1" />
   <spawnpoint posX="828.417603" posY="850.991516" posZ="11.646961" rotation="113" vehicle="468" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-rcairwar/RC Air War.map
+++ b/[gamemodes]/[race]/[maps]/race-rcairwar/RC Air War.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-2209.909180" posY="128.344604" posZ="57.314892" rotation="85" vehicle="464" id="spawnpoint0" />
   <spawnpoint posX="-2301.519287" posY="4.815262" posZ="51.212147" rotation="360" vehicle="464" id="spawnpoint1" />
   <spawnpoint posX="-2473.133057" posY="116.677582" posZ="64.344048" rotation="270" vehicle="464" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-rcwarz/RC War Z.map
+++ b/[gamemodes]/[race]/[maps]/race-rcwarz/RC War Z.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-3418.601318" posY="1245.294678" posZ="119.295441" rotation="90" vehicle="464" id="spawnpoint0" />
   <spawnpoint posX="-3551.884766" posY="1175.666748" posZ="120.096222" rotation="270" vehicle="464" id="spawnpoint1" />
   <spawnpoint posX="-3418.694824" posY="1242.574951" posZ="119.295441" rotation="90" vehicle="464" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-runway69/Runway 69.map
+++ b/[gamemodes]/[race]/[maps]/race-runway69/Runway 69.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-1276.744385" posY="226.018005" posZ="14.698620" rotation="317" vehicle="593" id="spawnpoint0" />
   <spawnpoint posX="-1267.244385" posY="216.768005" posZ="14.698620" rotation="317" vehicle="593" id="spawnpoint1" />
   <spawnpoint posX="-1284.912842" posY="217.842712" posZ="14.698620" rotation="317" vehicle="593" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-rustlerrampage/Rustler Rampage.map
+++ b/[gamemodes]/[race]/[maps]/race-rustlerrampage/Rustler Rampage.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="1286.194580" posY="1362.070190" posZ="11.990465" rotation="269" vehicle="476" id="spawnpoint0" />
   <spawnpoint posX="1286.167603" posY="1323.955566" posZ="11.990465" rotation="270" vehicle="476" id="spawnpoint1" />
   <spawnpoint posX="1294.452393" posY="1425.097778" posZ="11.990469" rotation="270" vehicle="476" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-sandking/Sandking.map
+++ b/[gamemodes]/[race]/[maps]/race-sandking/Sandking.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-546.414917" posY="-2641.711914" posZ="152.944366" rotation="95" vehicle="495" id="spawnpoint0" />
   <spawnpoint posX="-533.699036" posY="-2653.063232" posZ="154.946335" rotation="99" vehicle="495" id="spawnpoint1" />
   <spawnpoint posX="-555.373352" posY="-2641.618164" posZ="150.340820" rotation="114" vehicle="495" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-santosdrive/Santos Drive.map
+++ b/[gamemodes]/[race]/[maps]/race-santosdrive/Santos Drive.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="1697.760498" posY="-656.801758" posZ="42.595863" rotation="174" vehicle="560" id="spawnpoint0" />
   <spawnpoint posX="1700.535400" posY="-657.017090" posZ="42.593559" rotation="173" vehicle="560" id="spawnpoint1" />
   <spawnpoint posX="1703.296387" posY="-657.237549" posZ="42.604580" rotation="170" vehicle="560" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-seadragon/Sea Dragon.map
+++ b/[gamemodes]/[race]/[maps]/race-seadragon/Sea Dragon.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-605.329590" posY="1979.284546" posZ="-0.954924" rotation="137" vehicle="446" id="spawnpoint0" />
   <spawnpoint posX="-640.912415" posY="1999.203003" posZ="-0.625000" rotation="152" vehicle="446" id="spawnpoint1" />
   <spawnpoint posX="-616.579407" posY="1987.352173" posZ="-0.625000" rotation="144" vehicle="446" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-seahunter/Sea Hunter.map
+++ b/[gamemodes]/[race]/[maps]/race-seahunter/Sea Hunter.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="2429.433350" posY="-4184.613770" posZ="386.726166" rotation="99" vehicle="425" id="spawnpoint0" />
   <spawnpoint posX="2129.433350" posY="-4184.613770" posZ="326.726166" rotation="270" vehicle="425" id="spawnpoint1" />
   <spawnpoint posX="2729.433350" posY="-4184.613770" posZ="266.726166" rotation="90" vehicle="425" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-searustler/Sea Rustler.map
+++ b/[gamemodes]/[race]/[maps]/race-searustler/Sea Rustler.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="2429.433350" posY="-4184.613770" posZ="386.726166" rotation="99" vehicle="476" id="spawnpoint0" />
   <spawnpoint posX="2129.433350" posY="-4184.613770" posZ="326.726166" rotation="270" vehicle="476" id="spawnpoint1" />
   <spawnpoint posX="2729.433350" posY="-4184.613770" posZ="266.726166" rotation="90" vehicle="476" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-sewers/Sewers.map
+++ b/[gamemodes]/[race]/[maps]/race-sewers/Sewers.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="1356.942261" posY="-1719.952515" posZ="8.186823" rotation="355" vehicle="523" id="spawnpoint0" />
   <spawnpoint posX="1358.442261" posY="-1719.952515" posZ="8.186823" rotation="355" vehicle="523" id="spawnpoint1" />
   <spawnpoint posX="1356.942261" posY="-1717.202515" posZ="8.186823" rotation="355" vehicle="523" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-sfbynight/SF by Night.map
+++ b/[gamemodes]/[race]/[maps]/race-sfbynight/SF by Night.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-2534.042480" posY="-618.702881" posZ="132.412018" rotation="270" vehicle="415" id="spawnpoint0" />
   <spawnpoint posX="-2534.072266" posY="-614.638855" posZ="132.412018" rotation="270" vehicle="415" id="spawnpoint1" />
   <spawnpoint posX="-2534.109863" posY="-610.500183" posZ="132.412018" rotation="270" vehicle="415" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-smugglersrun/Smugglers Run.map
+++ b/[gamemodes]/[race]/[maps]/race-smugglersrun/Smugglers Run.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-1054.252441" posY="-1290.549194" posZ="128.197647" rotation="182" vehicle="535" id="spawnpoint0" />
   <spawnpoint posX="-1357.165161" posY="-1081.968018" posZ="161.966888" rotation="270" vehicle="425" id="spawnpoint1" />
   <spawnpoint posX="-1044.318481" posY="-1290.609619" posZ="128.075195" rotation="182" vehicle="535" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-sparrowstorm/Sparrow Storm.map
+++ b/[gamemodes]/[race]/[maps]/race-sparrowstorm/Sparrow Storm.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-2200.484863" posY="2421.825439" posZ="1.165230" rotation="225" vehicle="447" id="spawnpoint0" />
   <spawnpoint posX="-2333.987549" posY="2497.883301" posZ="1.189028" rotation="167" vehicle="447" id="spawnpoint1" />
   <spawnpoint posX="-2320.333984" posY="2294.191162" posZ="1.043757" rotation="178" vehicle="447" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-specialdelivery/Special Delivery.map
+++ b/[gamemodes]/[race]/[maps]/race-specialdelivery/Special Delivery.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="1407.548828" posY="-1307.454346" posZ="8.472756" rotation="185" vehicle="448" id="spawnpoint0" />
   <spawnpoint posX="1407.798828" posY="-1309.704346" posZ="8.472756" rotation="185" vehicle="448" id="spawnpoint1" />
   <spawnpoint posX="1408.673706" posY="-1307.454346" posZ="8.472756" rotation="185" vehicle="448" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-speedforweed/KWK SPEED FOR WEED.map
+++ b/[gamemodes]/[race]/[maps]/race-speedforweed/KWK SPEED FOR WEED.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="2910.158203" posY="2410.961914" posZ="10.789803" rotation="178" vehicle="503" id="spawnpoint0" />
   <spawnpoint posX="2907.432617" posY="2411.049561" posZ="10.789803" rotation="178" vehicle="503" id="spawnpoint1" />
   <spawnpoint posX="2904.544922" posY="2411.062500" posZ="10.789803" rotation="178" vehicle="503" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-squalorace/Squalo Race.map
+++ b/[gamemodes]/[race]/[maps]/race-squalorace/Squalo Race.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-2162.152100" posY="2422.663574" posZ="0.939317" rotation="178" vehicle="446" id="spawnpoint0" />
   <spawnpoint posX="-2129.694824" posY="2421.670654" posZ="1.021570" rotation="175" vehicle="446" id="spawnpoint1" />
   <spawnpoint posX="-2113.598877" posY="2421.328125" posZ="1.005153" rotation="170" vehicle="446" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-stunt/Stunt.map
+++ b/[gamemodes]/[race]/[maps]/race-stunt/Stunt.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-1402.330444" posY="1571.068970" posZ="1052.191650" rotation="360" vehicle="522" id="spawnpoint0" />
   <spawnpoint posX="-1405.571411" posY="1571.112061" posZ="1052.191650" rotation="360" vehicle="522" id="spawnpoint1" />
   <spawnpoint posX="-1408.787354" posY="1571.160522" posZ="1052.191650" rotation="360" vehicle="522" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-suburbanspeedway/Suburban Speedway.map
+++ b/[gamemodes]/[race]/[maps]/race-suburbanspeedway/Suburban Speedway.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="2844.980469" posY="907.545959" posZ="10.410378" rotation="90" vehicle="523" id="spawnpoint0" />
   <spawnpoint posX="2844.625000" posY="908.656677" posZ="10.410378" rotation="90" vehicle="523" id="spawnpoint1" />
   <spawnpoint posX="2844.175293" posY="909.853149" posZ="10.410378" rotation="90" vehicle="523" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-superhydrarace/Super Hydra Race.map
+++ b/[gamemodes]/[race]/[maps]/race-superhydrarace/Super Hydra Race.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="436.650116" posY="2522.341064" posZ="17.788849" rotation="92" vehicle="520" id="spawnpoint0" />
   <spawnpoint posX="437.269745" posY="2505.496338" posZ="17.711937" rotation="92" vehicle="520" id="spawnpoint1" />
   <spawnpoint posX="437.592468" posY="2490.112305" posZ="17.783958" rotation="92" vehicle="520" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-technicalitch/Technical Itch.map
+++ b/[gamemodes]/[race]/[maps]/race-technicalitch/Technical Itch.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-1040.011719" posY="-1222.541016" posZ="129.603882" rotation="185" vehicle="599" id="spawnpoint0" />
   <spawnpoint posX="-1049.397461" posY="-1225.491699" posZ="129.095230" rotation="185" vehicle="599" id="spawnpoint1" />
   <spawnpoint posX="-1046.218506" posY="-1224.681641" posZ="129.099823" rotation="185" vehicle="599" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-thepanopticon/The Panopticon.map
+++ b/[gamemodes]/[race]/[maps]/race-thepanopticon/The Panopticon.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="-540.145874" posY="-192.636398" posZ="78.677254" rotation="89" vehicle="489" id="spawnpoint0" />
   <spawnpoint posX="-540.044678" posY="-189.661148" posZ="78.702255" rotation="89" vehicle="489" id="spawnpoint1" />
   <spawnpoint posX="-539.944824" posY="-186.411209" posZ="78.727257" rotation="89" vehicle="489" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-vinewoodblastaround/Vinewood BLASTAround.map
+++ b/[gamemodes]/[race]/[maps]/race-vinewoodblastaround/Vinewood BLASTAround.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="1636.370972" posY="-1076.938477" posZ="23.590368" rotation="175" vehicle="565" id="spawnpoint0" />
   <spawnpoint posX="1638.945313" posY="-1078.135742" posZ="23.590368" rotation="175" vehicle="565" id="spawnpoint1" />
   <spawnpoint posX="1641.546875" posY="-1079.074951" posZ="23.598162" rotation="175" vehicle="565" id="spawnpoint2" />

--- a/[gamemodes]/[race]/[maps]/race-wuzimu/Wu Zi Mu.map
+++ b/[gamemodes]/[race]/[maps]/race-wuzimu/Wu Zi Mu.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="race"> 
   <spawnpoint posX="1563.538574" posY="24.465673" posZ="24.104063" rotation="185" vehicle="402" id="spawnpoint0" />
   <spawnpoint posX="1560.690552" posY="24.223686" posZ="24.104063" rotation="185" vehicle="402" id="spawnpoint1" />
   <spawnpoint posX="1557.838867" posY="24.083290" posZ="24.104063" rotation="185" vehicle="402" id="spawnpoint2" />

--- a/[gamemodes]/[stealth]/[maps]/sth-carrier/sth-carrier.map
+++ b/[gamemodes]/[stealth]/[maps]/sth-carrier/sth-carrier.map
@@ -1,4 +1,4 @@
-<map edf:definitions="stealth,editor_main">
+﻿<map edf:definitions="stealth">
     <mercenaryspawn id="mercenaryspawn (1)" interior="0" posX="-1253.73828125" posY="498.69299316406" posZ="18.234375" rotX="0" rotY="0" rotZ="0" />
     <mercenaryspawn id="mercenaryspawn (2)" interior="0" posX="-1255.0395507813" posY="498.6923828125" posZ="18.234375" rotX="0" rotY="0" rotZ="0" />
     <mercenaryspawn id="mercenaryspawn (3)" interior="0" posX="-1256.3393554688" posY="498.6923828125" posZ="18.234375" rotX="0" rotY="0" rotZ="0" />

--- a/[gamemodes]/[stealth]/[maps]/sth-chinatown/chinatown.map
+++ b/[gamemodes]/[stealth]/[maps]/sth-chinatown/chinatown.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="stealth"> 
    <camera posX="-2169.949219" posY="709.592712" posZ="100.451820" targetX="-2220.357178" targetY="662.977173" targetZ="63.059345"/>
    <team1 id="mercspawns">
       <spawnpoint id="team1" posX="-2160.597412" posY="590.774292" posZ="56.285034" rot="90" skin="285"/>

--- a/[gamemodes]/[stealth]/[maps]/sth-church/sth-churchEZ.map
+++ b/[gamemodes]/[stealth]/[maps]/sth-church/sth-churchEZ.map
@@ -1,4 +1,4 @@
-<map edf:definitions="stealth,editor_main">
+﻿<map edf:definitions="stealth">
     <object id="object (vgsbldng01_lvs) (5)" dimension="0" interior="0" model="8419" posX="-2297.6857910156" posY="1879.9576416016" posZ="-0.074999995529652" rotX="0" rotY="0" rotZ="0" />
     <object id="object (vgsbldng01_lvs) (6)" dimension="0" interior="0" model="8419" posX="-2252.1916503906" posY="1879.9381103516" posZ="0.024999044835567" rotX="0" rotY="0" rotZ="0" />
     <object id="object (vgsbldng01_lvs) (7)" dimension="0" interior="0" model="8419" posX="-2327.19921875" posY="1863.2353515625" posZ="12.675000190735" rotX="0" rotY="90" rotZ="0" />

--- a/[gamemodes]/[stealth]/[maps]/sth-coookiepirates/sth-CoookiePirates.map
+++ b/[gamemodes]/[stealth]/[maps]/sth-coookiepirates/sth-CoookiePirates.map
@@ -1,4 +1,4 @@
-<map>
+﻿<map edf:definitions="stealth">
 <maplimit>
 	<point x="3845.718506" y="1809.559814"/>
 	<point x="3973.697266" y="1891.671387"/>

--- a/[gamemodes]/[stealth]/[maps]/sth-dra-park/sth-dra-park.map
+++ b/[gamemodes]/[stealth]/[maps]/sth-dra-park/sth-dra-park.map
@@ -1,4 +1,4 @@
-<map edf:definitions="editor_main">
+﻿<map edf:definitions="stealth">
 
    <team1 id="mercspawns">
 	<spawnpoint id="team1" posX="-2034.263184" posY="830.503662" posZ="69.213318" rot="0" skin="166"/>

--- a/[gamemodes]/[stealth]/[maps]/sth-factory/factory.map
+++ b/[gamemodes]/[stealth]/[maps]/sth-factory/factory.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="stealth"> 
    <camera posX="2630.944824" posY="2783.625244" posZ="39.520676" targetX="2638.269775" targetY="2723.905762" targetZ="24.083593"/>
    <team1 id="mercspawns">
       <spawnpoint id="team1" posX="2503.764160" posY="2766.132813" posZ="11.480690" rot="90" skin="285"/>

--- a/[gamemodes]/[stealth]/[maps]/sth-junkyard/junkyard.map
+++ b/[gamemodes]/[stealth]/[maps]/sth-junkyard/junkyard.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="stealth"> 
    <camera posX="-1865.59" posY=" -1630.960" posZ="157.579" targetX="-1865.59" targetY=" -1631.960" targetZ="15.579"/>
    <maplimit>
       <point x="-1934.0812988281" y="-1783.662109375"/>

--- a/[gamemodes]/[stealth]/[maps]/sth-ritzy/ritzy.map
+++ b/[gamemodes]/[stealth]/[maps]/sth-ritzy/ritzy.map
@@ -1,4 +1,4 @@
-<map>
+﻿<map edf:definitions="stealth">
 
 <camera posX="-2599.462158" posY="948.766052" posZ="111.269463" targetX="-2653.292480" targetY="896.747070" targetZ="77.588188" />
 

--- a/[gamemodes]/[stealth]/[maps]/sth-sewers/sewers.map
+++ b/[gamemodes]/[stealth]/[maps]/sth-sewers/sewers.map
@@ -1,4 +1,4 @@
-<map>
+<map edf:definitions="stealth"> 
    <camera posX="215.447983" posY="-2163.096436" posZ="7.493396" targetX="230.330231" targetY="-2172.462646" targetZ="3.027212"/>
    <team1 id="mercspawns">
       <spawnpoint id="team1" posX="230.779465" posY="-2180.549561" posZ="5.153359" rot="90" skin="285"/>

--- a/[gamemodes]/[stealth]/[maps]/sth-shopping/ShoppingCenter.map
+++ b/[gamemodes]/[stealth]/[maps]/sth-shopping/ShoppingCenter.map
@@ -1,4 +1,4 @@
-<map>
+﻿<map edf:definitions="stealth">
    <camera posX="1802.479492" posY="-1307.990723" posZ="58.041718" targetX="1799.633667" targetY="-1312.242188" targetZ="56.224228"/>
    <team1 id="mercspawns">
       <spawnpoint id="team1" posX="1728.030151" posY="-1327.989380" posZ="13.246315" rot="220" skin="285"/>

--- a/[gamemodes]/[stealth]/[maps]/sth-terminal/sth-terminal.map
+++ b/[gamemodes]/[stealth]/[maps]/sth-terminal/sth-terminal.map
@@ -1,4 +1,4 @@
-<map edf:definitions="stealth,editor_main">
+<map edf:definitions="stealth"> 
     <object id="object (vgsEbuild01_lvs) (1)" model="8643" interior="0" dimension="0" posX="1520.4943847656" posY="-2306.9106445313" posZ="2.5529699325562" rotX="0" rotY="0" rotZ="180.63488769531" />
     <object id="object (vgsEbuild01_lvs) (2)" model="8643" interior="0" dimension="0" posX="1421.3387451172" posY="-2306.0256347656" posZ="2.6818208694458" rotX="0" rotY="0" rotZ="178.65002441406" />
     <object id="object (airportgate) (1)" model="980" interior="0" dimension="0" posX="1785.9881591797" posY="-2204.5114746094" posZ="15.320266723633" rotX="0" rotY="0" rotZ="179.65002441406" />

--- a/[gamemodes]/[stealth]/[maps]/sth-thebunker/TheBunker.map
+++ b/[gamemodes]/[stealth]/[maps]/sth-thebunker/TheBunker.map
@@ -1,4 +1,4 @@
-<map>
+﻿<map edf:definitions="stealth">
    <camera posX="730.304443" posY="-2369.834473" posZ="36.444778" targetX="657.290527" targetY="-2382.009766" targetZ="17.308689"/>
    <team1 id="mercspawns">
       <spawnpoint id="team1" posX="887.235596" posY="-2415.709473" posZ="20.422794" rot="60" skin="285"/>


### PR DESCRIPTION
This PR adds missing definitions to old maps, previously it will load the map without EDF elements