### PR TITLE
editor: Fix an issue where loading a small map overwrites map settings

### DIFF
--- a/[editor]/editor_gui/client/mapsettings_gamemodesettings.lua
+++ b/[editor]/editor_gui/client/mapsettings_gamemodesettings.lua
@@ -5,27 +5,33 @@ mapsettings.gamemodeSettings = {}
 local valueWidget
 local isHandled
 addEventHandler ( "doLoadEDF", root,
-function(tableEDF, resource)
+function(tableEDF, resource, isMapLoading)
 	--store all our data neatly under the resource
 	edfSettings[resource] = tableEDF["settings"]
 	refreshGamemodeSettings()
 	--send back the intepreted gui table so the server knows the settings !!Lazy, server could interpret this info or only one client could send it
-	mapsettings.gamemodeSettings = copyTable ( mapsettings.rowValues )
-	currentMapSettings.rowData = rowData
-	currentMapSettings.gamemodeSettings = mapsettings.gamemodeSettings
-	triggerServerEvent ( "doSaveMapSettings", localPlayer, currentMapSettings, true )
+	-- prevent edf from overwriting map settings while the map is being loaded
+	if not isMapLoading then
+		mapsettings.gamemodeSettings = copyTable ( mapsettings.rowValues )
+		currentMapSettings.rowData = rowData
+		currentMapSettings.gamemodeSettings = mapsettings.gamemodeSettings
+		triggerServerEvent ( "doSaveMapSettings", localPlayer, currentMapSettings, true )
+	end
 end )
 
 addEventHandler ( "doUnloadEDF", root,
-function(resource)
+function(resource, isMapLoading)
 	--store all our data neatly under the resource
 	edfSettings[resource] = nil
 	refreshGamemodeSettings()
 	--send back the intepreted gui table so the server knows the settings !!Lazy, server could interpret this info or only one client could send it
-	mapsettings.gamemodeSettings = copyTable ( mapsettings.rowValues )
-	currentMapSettings.rowData = rowData
-	currentMapSettings.gamemodeSettings = mapsettings.gamemodeSettings
-	triggerServerEvent ( "doSaveMapSettings", localPlayer, currentMapSettings, true )
+	-- prevent edf from overwriting map settings while the map is being loaded
+	if not isMapLoading then
+		mapsettings.gamemodeSettings = copyTable ( mapsettings.rowValues )
+		currentMapSettings.rowData = rowData
+		currentMapSettings.gamemodeSettings = mapsettings.gamemodeSettings
+		triggerServerEvent ( "doSaveMapSettings", localPlayer, currentMapSettings, true )
+	end
 end )
 
 function refreshGamemodeSettings()

--- a/[editor]/editor_main/server/EDFhandler.lua
+++ b/[editor]/editor_main/server/EDFhandler.lua
@@ -33,7 +33,8 @@ function registerEDF( resource )
 	loadedEDF[resource] = edf.edfGetDefinition(resource)
 	for i, player in ipairs(getElementsByType"player") do
 		if clientGUILoaded[player] then
-			triggerClientEvent ( player, "doLoadEDF", root, loadedEDF[resource], getResourceName ( resource ) )
+			local isMapLoading = isEditorOpeningResource()
+			triggerClientEvent ( player, "doLoadEDF", root, loadedEDF[resource], getResourceName ( resource ), isMapLoading )
 		end
 	end
 end
@@ -45,7 +46,8 @@ addEventHandler ( "onEDFUnload", root,
 		loadedEDF[resource] = nil
 		for i, player in ipairs(getElementsByType"player") do
 			if clientGUILoaded[player] then
-				triggerClientEvent ( player, "doUnloadEDF", root, getResourceName ( resource ) )
+				local isMapLoading = isEditorOpeningResource()
+				triggerClientEvent ( player, "doUnloadEDF", root, getResourceName ( resource ), isMapLoading )
 			end
 		end
 	end
@@ -54,7 +56,8 @@ addEventHandler ( "onEDFUnload", root,
 local function sendEDF()
 	clientGUILoaded[source] = true
 	for resource, resourceDefinition in pairs(loadedEDF) do
-		triggerClientEvent ( source, "doLoadEDF", root, resourceDefinition, getResourceName ( resource ) )
+		local isMapLoading = isEditorOpeningResource()
+		triggerClientEvent ( source, "doLoadEDF", root, resourceDefinition, getResourceName ( resource ), isMapLoading )
 	end
 end
 addEventHandler ( "onClientGUILoaded", root, sendEDF)


### PR DESCRIPTION
Fixes #548 

This happens because smaller maps load faster before the event reaches the client, this check will prevent map settings from being overwritten when EDF is loaded

resource: [bug.zip](https://github.com/user-attachments/files/22309534/bug.zip)


before: 

https://github.com/user-attachments/assets/eb5565c3-7ac1-41ba-95b1-cb98076f638b


after:

https://github.com/user-attachments/assets/f19f62ca-e023-41a2-bbf0-48ab9f5378b8