### PR TITLE
admin: Fix gridlist bug

### DIFF
--- a/[admin]/admin/client/gui/admin_main.lua
+++ b/[admin]/admin/client/gui/admin_main.lua
@@ -145,9 +145,9 @@ y=y+B  aTab1.VehicleHealth	= guiCreateLabel ( 0.26, y, 0.25, 0.04, "Vehicle Heal
 				aCurrentWeapon = weaponID
 				guiSetText(aTab1.GiveWeapon, "Give: " .. (shortNames[selectedText] or selectedText))
 			else
-				local weaponID = getWeaponIDFromName(selectedText)
-				if weaponID then
-					aCurrentWeapon = weaponID
+				local fallbackWeaponID = getWeaponIDFromName(selectedText)
+				if fallbackWeaponID then
+					aCurrentWeapon = fallbackWeaponID
 					guiSetText(aTab1.GiveWeapon, "Give: " .. (shortNames[selectedText] or selectedText))
 				end
 			end
@@ -184,9 +184,9 @@ y=y+B  aTab1.VehicleHealth	= guiCreateLabel ( 0.26, y, 0.25, 0.04, "Vehicle Heal
 				aCurrentVehicle = modelID
 				guiSetText ( aTab1.GiveVehicle, "Give: "..selectedText )
 			else
-				local modelID = getVehicleModelFromName(selectedText)
-				if modelID then
-					aCurrentVehicle = modelID
+				local fallbackModelID = getVehicleModelFromName(selectedText)
+				if fallbackModelID then
+					aCurrentVehicle = fallbackModelID
 					guiSetText ( aTab1.GiveVehicle, "Give: "..selectedText )
 				end
 			end


### PR DESCRIPTION
there was a bug with gridlist, if you flip it and then search and try to select something it gives [guiGridListGetItemData](https://wiki.multitheftauto.com/wiki/GuiGridListGetItemData) always nil.

Bug Preview:

https://github.com/user-attachments/assets/9b764a53-ad4c-48c1-a113-ae24764cb5da

so this PR just adds a fallback to get the id from text for weapons/vehicles
