### PR TITLE
editor_gui: Fix overlapping checkboxes

### DIFF
--- a/[editor]/editor_gui/client/options_gui.lua
+++ b/[editor]/editor_gui/client/options_gui.lua
@@ -20,7 +20,7 @@ function createOptionsDialog()
 	dialog.restoreDefaults = guiCreateButton ( 0.02, 0.919444, 0.22857142, 0.05555555, "Restore defaults", true, dialog.window )
 
 	--create general settings
-	dialog.enableSounds = editingControl.boolean:create{["x"]=0.02,["y"]=0.02,["width"]=1,["height"]=0.1,["relative"]=true,["parent"]=dialog.generalTab,["label"]="Enable Sounds"}
+	dialog.enableSounds = editingControl.boolean:create{["x"]=0.02,["y"]=0.02,["width"]=0.35,["height"]=0.1,["relative"]=true,["parent"]=dialog.generalTab,["label"]="Enable Sounds"}
 	guiCreateLabel ( 0.02, 0.14, 1, 0.1, "Icon size:", true, dialog.generalTab )
 	guiCreateLabel ( 0.02, 0.34, 1, 0.1, "Control panel alignment:", true, dialog.generalTab )
 	guiCreateLabel ( 0.02, 0.54, 1, 0.1, "Element creation panel alignment:", true, dialog.generalTab )
@@ -29,23 +29,23 @@ function createOptionsDialog()
 	dialog.topAlign = editingControl.dropdown:create{["x"]=0.02,["y"]=0.4,["width"]=0.30,["height"]=0.07,["dropWidth"]=0.30,["dropHeight"]=0.35,["relative"]=true,["parent"]=dialog.generalTab,["rows"]={"left","right","center"}}
 	dialog.bottomAlign = editingControl.dropdown:create{["x"]=0.02,["y"]=0.6,["width"]=0.30,["height"]=0.07,["dropWidth"]=0.30,["dropHeight"]=0.35,["relative"]=true,["parent"]=dialog.generalTab,["rows"]={"left","right","center"}}
 
-	dialog.tutorialOnStart = editingControl.boolean:create{["x"]=0.02,["y"]=0.8,["width"]=1,["height"]=0.1,["relative"]=true,["parent"]=dialog.generalTab,["label"]="Query for tutorial on start"}
+	dialog.tutorialOnStart = editingControl.boolean:create{["x"]=0.02,["y"]=0.8,["width"]=0.35,["height"]=0.1,["relative"]=true,["parent"]=dialog.generalTab,["label"]="Query for tutorial on start"}
 
 	---------------------------------
-	dialog.enableBox = editingControl.boolean:create{["x"]=0.60,["y"]=0.02,["width"]=1,["height"]=0.1,["relative"]=true,["parent"]=dialog.generalTab,["label"]="Enable Bounding Box"}
-	dialog.enableXYZlines = editingControl.boolean:create{["x"]=0.60,["y"]=0.12,["width"]=1,["height"]=0.1,["relative"]=true,["parent"]=dialog.generalTab,["label"]="Enable XYZ Lines"}
+	dialog.enableBox = editingControl.boolean:create{["x"]=0.60,["y"]=0.02,["width"]=0.35,["height"]=0.1,["relative"]=true,["parent"]=dialog.generalTab,["label"]="Enable Bounding Box"}
+	dialog.enableXYZlines = editingControl.boolean:create{["x"]=0.60,["y"]=0.12,["width"]=0.35,["height"]=0.1,["relative"]=true,["parent"]=dialog.generalTab,["label"]="Enable XYZ Lines"}
 	---------------------------------
-	dialog.enablePrecisionSnap = editingControl.boolean:create{["x"]=0.60,["y"]=0.22,["width"]=1,["height"]=0.1,["relative"]=true,["parent"]=dialog.generalTab,["label"]="Enable Snap - Precise Position"}
+	dialog.enablePrecisionSnap = editingControl.boolean:create{["x"]=0.60,["y"]=0.22,["width"]=0.35,["height"]=0.1,["relative"]=true,["parent"]=dialog.generalTab,["label"]="Enable Snap - Precise Position"}
 	guiCreateLabel ( 0.47, 0.34, 70, 17, "Position Snap Level:", true, dialog.generalTab )
 	dialog.precisionLevel = editingControl.dropdown:create{["x"]=0.68,["y"]=0.34,["width"]=0.3,["height"]=0.07,["dropWidth"]=0.30,["dropHeight"]=0.55,["relative"]=true,["rows"]={"10","5","2","1","0.1","0.01","0.001","0.0001"},["parent"]=dialog.generalTab}
 	guiCreateLabel ( 0.47, 0.44, 70, 17, "Rotation Snap Level:", true, dialog.generalTab )
 	dialog.precisionRotLevel = editingControl.dropdown:create{["x"]=0.68,["y"]=0.44,["width"]=0.3,["height"]=0.07,["dropWidth"]=0.30,["dropHeight"]=0.55,["relative"]=true,["rows"]={"180","90","45","30","20","10","5","1"},["parent"]=dialog.generalTab}
-	dialog.enablePrecisionRotation = editingControl.boolean:create{["x"]=0.60,["y"]=0.52,["width"]=1,["height"]=0.1,["relative"]=true,["parent"]=dialog.generalTab,["label"]="Enable Snap - Precise Rotation"}
+	dialog.enablePrecisionRotation = editingControl.boolean:create{["x"]=0.60,["y"]=0.52,["width"]=0.35,["height"]=0.1,["relative"]=true,["parent"]=dialog.generalTab,["label"]="Enable Snap - Precise Rotation"}
 	guiCreateLabel ( 0.47, 0.64, 70, 17, "Scaling Snap Level:", true, dialog.generalTab )
 	dialog.elemScalingSnap = editingControl.dropdown:create{["x"]=0.68,["y"]=0.64,["width"]=0.3,["height"]=0.07,["dropWidth"]=0.30,["dropHeight"]=0.55,["relative"]=true,["rows"]={"1","0.1","0.01","0.001","0.0001"},["parent"]=dialog.generalTab}
 	---------------------------------
-	dialog.enableColPatch = editingControl.boolean:create{["x"]=0.60,["y"]=0.72,["width"]=1,["height"]=0.1,["relative"]=true,["parent"]=dialog.generalTab,["label"]="Enable collision patches"}
-	dialog.enableRotPatch = editingControl.boolean:create{["x"]=0.60,["y"]=0.82,["width"]=1,["height"]=0.1,["relative"]=true,["parent"]=dialog.generalTab,["label"]="Enable rotation patches"}
+	dialog.enableColPatch = editingControl.boolean:create{["x"]=0.60,["y"]=0.72,["width"]=0.35,["height"]=0.1,["relative"]=true,["parent"]=dialog.generalTab,["label"]="Enable collision patches"}
+	dialog.enableRotPatch = editingControl.boolean:create{["x"]=0.60,["y"]=0.82,["width"]=0.35,["height"]=0.1,["relative"]=true,["parent"]=dialog.generalTab,["label"]="Enable rotation patches"}
 	---------------------------------
 	--camera settings
 	guiCreateLabel ( 0.02, 0.02, 1, 0.1, "Normal camera move speed:", true, dialog.cameraTab )
@@ -75,8 +75,8 @@ function createOptionsDialog()
 		["max"]=90,
 	}
 
-	dialog.smoothCamMove = editingControl.boolean:create{["x"]=0.5,["y"]=0.22,["width"]=1,["height"]=0.1,["relative"]=true,["parent"]=dialog.cameraTab,["label"]="Smooth Camera movement"}
-	dialog.invertMouseLook = editingControl.boolean:create{["x"]=0.5,["y"]=0.32,["width"]=1,["height"]=0.1,["relative"]=true,["parent"]=dialog.cameraTab,["label"]="Invert mouse look"}
+	dialog.smoothCamMove = editingControl.boolean:create{["x"]=0.5,["y"]=0.22,["width"]=0.35,["height"]=0.1,["relative"]=true,["parent"]=dialog.cameraTab,["label"]="Smooth Camera movement"}
+	dialog.invertMouseLook = editingControl.boolean:create{["x"]=0.5,["y"]=0.32,["width"]=0.35,["height"]=0.1,["relative"]=true,["parent"]=dialog.cameraTab,["label"]="Invert mouse look"}
 	--create movement settings
 	guiCreateLabel ( 0.02, 0.12, 1, 0.1, "Normal element movement speed:", true, dialog.movementTab )
 	guiCreateLabel ( 0.02, 0.32, 1, 0.1, "Fast element movement speed:", true, dialog.movementTab )
@@ -161,7 +161,7 @@ addEvent("enableServerSettings", true)
 addEventHandler("enableServerSettings", root,
 	function(enabled, interval)
 		dialog.serverTab = guiCreateTab("Server Settings",tabpanel)
-		dialog.enableDumpSave = editingControl.boolean:create{["x"]=0.02,["y"]=0.02,["width"]=1,["height"]=0.1,["relative"]=true,["value"]=enabled,["parent"]=dialog.serverTab,["label"]="Enable Map Backup"}
+		dialog.enableDumpSave = editingControl.boolean:create{["x"]=0.02,["y"]=0.02,["width"]=0.35,["height"]=0.1,["relative"]=true,["value"]=enabled,["parent"]=dialog.serverTab,["label"]="Enable Map Backup"}
 		guiCreateLabel ( 0.02, 0.14, 1, 0.1, "Map Backup Interval (seconds):", true, dialog.serverTab )
 		dialog.dumpSaveInterval = editingControl.integer:create{["x"]=0.02,["y"]=0.2,["width"]=0.30,["height"]=0.07,["relative"]=true,["value"]=interval,["parent"]=dialog.serverTab }
 	end


### PR DESCRIPTION
Fix an issue where clicking on "enable sounds" or "enable bounding box" causes overlapping

Before:
<img width="663/3" height="364/3" alt="2025-09-19_14-07" src="https://github.com/user-attachments/assets/e11f0ef6-46f5-44a2-9dab-501d817b4109" />


After:
<img width="646/3" height="372/3" alt="2025-09-19_14-21" src="https://github.com/user-attachments/assets/9e88d72c-4096-44d2-ac4b-372e533e63df" />
