### PR TITLE
superman: fix bug

### DIFF
--- a/[gameplay]/superman/CHandleSuperman.lua
+++ b/[gameplay]/superman/CHandleSuperman.lua
@@ -162,6 +162,7 @@ function onClientPlayerWastedSuperman()
 		return false
 	end
 
+	setGravity(serverGravity)
 	restorePlayerFromSuperman(localPlayer)
 end
 


### PR DESCRIPTION
- Steps to reproduce
1. Enable superman using /superman or double shift
2. Click on F1 > kill or set your HP to 0 while moving
3. Your ped can no longer move.

In this PR this bug fixed.