### PR TITLE
Fix triggerClientEvent nil argument in admin chat handler

### DIFF
--- a/[admin]/admin2/server/admin_server.lua
+++ b/[admin]/admin2/server/admin_server.lua
@@ -407,12 +407,13 @@ addEventHandler(
     "aAdminChat",
     root,
     function(chat)
-        if #chat > ADMIN_CHAT_MAXLENGTH then
+        local sender = client or source
+        if not chat or #chat > (ADMIN_CHAT_MAXLENGTH or 255) then
             return
         end
-        for id, player in ipairs(getElementsByType("player")) do
-            if (aPlayers[player]["chat"]) then
-                triggerClientEvent(player, "aClientAdminChat", client, chat)
+        for _, player in ipairs(getElementsByType("player")) do
+            if aPlayers[player] and aPlayers[player]["chat"] then
+                triggerClientEvent(player, "aClientAdminChat", sender, chat)
             end
         end
     end


### PR DESCRIPTION
The variable client was returning nil when the command was triggered from the console (F8) or a command handler, causing the script to fail because `triggerClientEvent` requires a valid player 
element as the 3rd argument (source).

<img width="555" height="127" alt="Screenshot_5" src="https://github.com/user-attachments/assets/c30711ca-7d5e-4531-88b6-177b8fc4cf94" />

