### PR TITLE
Fix: handle resource names with special characters in admin settings

### DIFF
--- a/[admin]/admin/server/admin_settings.lua
+++ b/[admin]/admin/server/admin_settings.lua
@@ -33,9 +33,11 @@ function aGetResourceSettings( resName, bCountOnly )
 			if allowedAccess[string.sub(rawname,1,1)] then
 				count = count + 1
 				-- Remove leading '*','#' or '@'
-				local temp = string.gsub(rawname,'[%*%#%@](.*)','%1')
+				local temp = string.gsub(rawname, '^[%*%#%@](.*)', '%1')
+				-- Escape special characters inside resName
+				local safeResName = string.gsub(resName, '([^%w])', '%%%1')
 				-- Remove leading 'resName.'
-				local name = string.gsub(temp,resName..'%.(.*)','%1')
+				local name = string.gsub(temp, '^' .. safeResName .. '%.(.*)$', '%1')
 				-- If name didn't have a leading 'resName.', then it must be the default setting
 				local bIsDefault = ( temp == name )
 				if settings[name] == nil then

--- a/[admin]/admin/server/admin_settings.lua
+++ b/[admin]/admin/server/admin_settings.lua
@@ -27,6 +27,9 @@ function aGetResourceSettings( resName, bCountOnly )
 		return {}, count
 	end
 	local settings = {}
+	-- Escape special characters inside resName
+	local safeResName = string.gsub(resName, '([^%w])', '%%%1')
+	local namePattern = '^' .. safeResName .. '%.(.*)$'
 	-- Parse raw settings
 	for rawname,value in pairs(rawsettings) do
 		if allowedTypes[type(value)] then
@@ -34,10 +37,8 @@ function aGetResourceSettings( resName, bCountOnly )
 				count = count + 1
 				-- Remove leading '*','#' or '@'
 				local temp = string.gsub(rawname, '^[%*%#%@](.*)', '%1')
-				-- Escape special characters inside resName
-				local safeResName = string.gsub(resName, '([^%w])', '%%%1')
 				-- Remove leading 'resName.'
-				local name = string.gsub(temp, '^' .. safeResName .. '%.(.*)$', '%1')
+				local name = string.gsub(temp, namePattern, '%1')
 				-- If name didn't have a leading 'resName.', then it must be the default setting
 				local bIsDefault = ( temp == name )
 				if settings[name] == nil then

--- a/[admin]/admin/server/admin_settings.lua
+++ b/[admin]/admin/server/admin_settings.lua
@@ -27,15 +27,18 @@ function aGetResourceSettings( resName, bCountOnly )
 		return {}, count
 	end
 	local settings = {}
+	-- Escape special characters inside resName
+	local safeResName = string.gsub(resName, '([^%w])', '%%%1')
+	local namePattern = '^' .. safeResName .. '%.(.*)$'
 	-- Parse raw settings
 	for rawname,value in pairs(rawsettings) do
 		if allowedTypes[type(value)] then
 			if allowedAccess[string.sub(rawname,1,1)] then
 				count = count + 1
 				-- Remove leading '*','#' or '@'
-				local temp = string.gsub(rawname,'[%*%#%@](.*)','%1')
+				local temp = string.gsub(rawname, '^[%*%#%@](.*)', '%1')
 				-- Remove leading 'resName.'
-				local name = string.gsub(temp,resName..'%.(.*)','%1')
+				local name = string.gsub(temp, namePattern, '%1')
 				-- If name didn't have a leading 'resName.', then it must be the default setting
 				local bIsDefault = ( temp == name )
 				if settings[name] == nil then

--- a/[admin]/admin2/server/admin_ACL.lua
+++ b/[admin]/admin2/server/admin_ACL.lua
@@ -122,14 +122,15 @@ function getResourceSettings(resName, bCountOnly)
         return {}, count
     end
     local settings = {}
+    local safeResName = string.gsub(resName, '([^%w])', '%%%1')
+    local namePattern = '^' .. safeResName .. '%.(.*)$'
 
     for rawname, value in pairs(rawsettings) do
         if (allowedTypes[type(value)]) then
             if allowedAccess[string.sub(rawname, 1, 1)] then
                 count = count + 1
                 local temp = string.gsub(rawname, '^[%*%#%@](.*)', '%1')
-                local safeResName = string.gsub(resName, '([^%w])', '%%%1')
-                local name = string.gsub(temp, '^' .. safeResName .. '%.(.*)$', '%1')
+                local name = string.gsub(temp, namePattern, '%1')
                 local bIsDefault = (temp == name)
                 if (not settings[name]) then
                     settings[name] = {}

--- a/[admin]/admin2/server/admin_ACL.lua
+++ b/[admin]/admin2/server/admin_ACL.lua
@@ -122,13 +122,15 @@ function getResourceSettings(resName, bCountOnly)
         return {}, count
     end
     local settings = {}
+    local safeResName = string.gsub(resName, '([^%w])', '%%%1')
+    local namePattern = '^' .. safeResName .. '%.(.*)$'
 
     for rawname, value in pairs(rawsettings) do
         if (allowedTypes[type(value)]) then
             if allowedAccess[string.sub(rawname, 1, 1)] then
                 count = count + 1
-                local temp = string.gsub(rawname, "[%*%#%@](.*)", "%1")
-                local name = string.gsub(temp, resName .. "%.(.*)", "%1")
+                local temp = string.gsub(rawname, '^[%*%#%@](.*)', '%1')
+                local name = string.gsub(temp, namePattern, '%1')
                 local bIsDefault = (temp == name)
                 if (not settings[name]) then
                     settings[name] = {}

--- a/[admin]/admin2/server/admin_ACL.lua
+++ b/[admin]/admin2/server/admin_ACL.lua
@@ -127,8 +127,9 @@ function getResourceSettings(resName, bCountOnly)
         if (allowedTypes[type(value)]) then
             if allowedAccess[string.sub(rawname, 1, 1)] then
                 count = count + 1
-                local temp = string.gsub(rawname, "[%*%#%@](.*)", "%1")
-                local name = string.gsub(temp, resName .. "%.(.*)", "%1")
+                local temp = string.gsub(rawname, '^[%*%#%@](.*)', '%1')
+                local safeResName = string.gsub(resName, '([^%w])', '%%%1')
+                local name = string.gsub(temp, '^' .. safeResName .. '%.(.*)$', '%1')
                 local bIsDefault = (temp == name)
                 if (not settings[name]) then
                     settings[name] = {}


### PR DESCRIPTION
Closes #721 

Fix aGetResourceSettings and getResourceSettings pattern matching in admin and admin2
The previous gsub calls had two bugs:
1. The leading `'*','#','@'` strip pattern was unanchored, so the character could be stripped from the middle of a name.
2. resName was interpolated into a Lua pattern without escaping, so resources whose names contain special characters (like `-`) would produce wrong results.
Anchor both patterns with '^' and escape special characters in resName.