### PR TITLE
Add licenseplate resource

### DIFF
--- a/[gameplay]/licenseplate/client.lua
+++ b/[gameplay]/licenseplate/client.lua
@@ -1,0 +1,89 @@
+local GUI = {
+    button = {},
+    window = {},
+    label = {},
+    edit = {}
+}
+
+local isWindowOpen = false
+
+function createLicenseWindow()
+    if GUI.window[1] then return end 
+
+    GUI.window[1] = guiCreateWindow(671, 319, 307, 152, "License plate", false)
+    guiWindowSetSizable(GUI.window[1], false)
+
+    GUI.edit[1] = guiCreateEdit(13, 46, 284, 44, "", false, GUI.window[1])
+    GUI.label[1] = guiCreateLabel(16, 23, 281, 19, "Specify the number you want to install.", false, GUI.window[1])
+    guiSetFont(GUI.label[1], "default-bold-small")
+
+    GUI.button[1] = guiCreateButton(9, 104, 129, 38, "Set the number", false, GUI.window[1])
+    GUI.button[2] = guiCreateButton(168, 104, 129, 38, "Cancel", false, GUI.window[1])
+
+    guiSetVisible(GUI.window[1], false)
+end
+
+function showLicenseWindow()
+    if isWindowOpen then
+        hideLicenseWindow()
+        return
+    end
+
+    if not GUI.window[1] then
+        createLicenseWindow()
+    end
+    guiSetVisible(GUI.window[1], true)
+    guiSetInputEnabled(true)
+    guiBringToFront(GUI.window[1])
+    guiSetText(GUI.edit[1], "") 
+    isWindowOpen = true
+end
+
+function hideLicenseWindow()
+    if GUI.window[1] then
+        guiSetVisible(GUI.window[1], false)
+        guiSetInputEnabled(false)
+        isWindowOpen = false
+    end
+end
+
+addCommandHandler("setplate", showLicenseWindow)
+addCommandHandler("license", showLicenseWindow)
+
+function onClientGUIClick(button, state)
+    if button ~= "left" or state ~= "up" then return end
+    local clicked = source
+    if clicked == GUI.button[1] then
+        local plate = guiGetText(GUI.edit[1])
+        plate = plate:gsub("^%s*(.-)%s*$", "%1")
+
+        if plate == "" then
+            outputChatBox("Please enter a license plate number.", 255, 0, 0)
+            return
+        end
+
+        if #plate > 8 then
+            outputChatBox("License plate cannot exceed 8 characters.", 255, 0, 0)
+            return
+        end
+
+        -- (Optionally – uncomment if necessary)
+        -- if not string.match(plate, "^[A-Za-z0-9 ]+$") then
+        --     outputChatBox("License plate contains invalid characters. Use only letters, numbers and spaces.", 255, 0, 0)
+        --     return
+        -- end
+
+        local vehicle = getPedOccupiedVehicle(localPlayer)
+        if not vehicle then
+            outputChatBox("You are not in a vehicle.", 255, 0, 0)
+            return
+        end
+
+        triggerServerEvent("LicensePlate:set", localPlayer, vehicle, plate)
+        hideLicenseWindow()
+
+    elseif clicked == GUI.button[2] then
+        hideLicenseWindow()
+    end
+end
+addEventHandler("onClientGUIClick", root, onClientGUIClick)

--- a/[gameplay]/licenseplate/meta.xml
+++ b/[gameplay]/licenseplate/meta.xml
@@ -1,0 +1,7 @@
+<meta>
+	<info author="MTA contributors (github.com/multitheftauto/mtasa-resources)" version="1.0" type="script" description="Basic license plate" />
+
+	<script src="client.lua" type="client" />
+
+	<script src="server.lua" type="server" />
+</meta>

--- a/[gameplay]/licenseplate/server.lua
+++ b/[gameplay]/licenseplate/server.lua
@@ -1,0 +1,26 @@
+addEvent("LicensePlate:set", true)
+addEventHandler("LicensePlate:set", root,
+    function(vehicle, plate)
+        local player = source
+
+        if not player or not isElement(player) then return end
+        if not vehicle or not isElement(vehicle) then return end
+
+        if getPedOccupiedVehicle(player) ~= vehicle then
+            outputChatBox("You are not in that vehicle.", player, 255, 0, 0)
+            return
+        end
+
+        if #plate > 8 then
+            outputChatBox("License plate too long.", player, 255, 0, 0)
+            return
+        end
+        --[[if not string.match(plate, "^[A-Za-z0-9 ]+$") then
+            outputChatBox("Invalid characters in license plate.", player, 255, 0, 0)
+            return
+        end]]
+
+        setVehiclePlateText(vehicle, plate)
+        outputChatBox("License plate set to: " .. plate, player, 0, 255, 0)
+    end
+)


### PR DESCRIPTION

**Type:** New resource

**Summary**
Adds a new `[gameplay]/licenseplate` resource that lets players set a custom license plate on the vehicle they are currently driving through a small in-game GUI window.

**What the resource does**
- **Client (`client.lua`)**
  - Creates a small GUI window ("License plate") with a text field, a "Set the number" button and a "Cancel" button.
  - Opens the window with the commands `/setplate` and its alias `/license`.
  - Validates the input on the client side:
    - rejects an empty plate with a chat message;
    - rejects plates longer than 8 characters (matching the vanilla plate limit);
    - an optional letter/number/space-only check is provided but commented out.
  - Checks that the player is actually inside a vehicle before continuing.
  - Triggers the server-side event `LicensePlate:set` with the vehicle and the plate, then hides the window.
- **Server (`server.lua`)**
  - Listens for the `LicensePlate:set` event.
  - Validates the player, the vehicle and that the player is still inside that vehicle.
  - Enforces the 8-character limit again server-side (trusted check).
  - Applies the plate with `setVehiclePlateText` and confirms with a chat message.

**Files**
- `client.lua` - GUI creation, input validation, commands and event triggering.
- `server.lua` - validation and applying the plate via `setVehiclePlateText`.
- `meta.xml` - resource definition, registers the client and server scripts.

**Tested**
- Opening/closing the window via both commands.
- Empty input, oversized input and a valid plate.
- Setting a plate while not in a vehicle.