### PR TITLE
editor: Fix editor breaking on old race maps with legacy rotation

### DIFF
--- a/[editor]/edf/edf.lua
+++ b/[editor]/edf/edf.lua
@@ -858,7 +858,7 @@ function edfGetElementPosition(element)
 	end
 end
 
---Returns an element's rotation, or its rotX/Y/Z element data, or false
+--Returns an element's rotation, or its rotX/Y/Z element data, or 0,0,0
 function edfGetElementRotation(element)
 	local etype = getElementType(element)
 	local rx, ry, rz
@@ -871,15 +871,12 @@ function edfGetElementRotation(element)
 		else
 			rx = tonumber(getElementData(element,"rotX"))
 			ry = tonumber(getElementData(element,"rotY"))
-			rz = tonumber(getElementData(element,"rotZ"))
+			-- old race maps use rotation="360" instead of rotX/Y/Z
+			rz = tonumber(getElementData(element,"rotZ")) or tonumber(getElementData(element,"rotation"))
 		end
 	end
 
-	if rx and ry and rz then
-		return rx, ry, rz
-	else
-		return false
-	end
+	return rx or 0, ry or 0, rz or 0
 end
 
 --Returns an element's scale, or its scale element data, or false

--- a/[editor]/edf/edf_client.lua
+++ b/[editor]/edf/edf_client.lua
@@ -112,15 +112,12 @@ function edfGetElementRotation(element)
 		else
 			rx = tonumber(getElementData(element,"rotX"))
 			ry = tonumber(getElementData(element,"rotY"))
-			rz = tonumber(getElementData(element,"rotZ"))
+			-- old race maps use rotation="360" instead of rotX/Y/Z
+			rz = tonumber(getElementData(element,"rotZ")) or tonumber(getElementData(element,"rotation"))
 		end
 	end
 
-	if rx and ry and rz then
-		return rx, ry, rz
-	else
-		return false
-	end
+	return rx or 0, ry or 0, rz or 0
 end
 
 --Returns an element's scale, or its scale element data, or 1

--- a/[editor]/editor_main/server/saveloadtest_server.lua
+++ b/[editor]/editor_main/server/saveloadtest_server.lua
@@ -723,6 +723,10 @@ function createElementAttributesForSaving(xmlNode, element)
 			xmlNodeSetAttribute(elementNode, "posZ", toAttribute(round(dataValue[3], 5)))
 			posSetX, posSetY, posSetZ = true, true, true
 		elseif ( dataName == "rotation" ) then
+			-- old race maps rotation isn't a table, so we need to convert it to a table
+			if type(dataValue) ~= "table" then
+				dataValue = { 0, 0, tonumber(dataValue) or 0 }
+			end
 			if dataValue[4] == "ZYX" then
 				local skipConversion = getElementType(element) == "vehicle"
 				if not skipConversion then


### PR DESCRIPTION
old race maps store rotation as a single `rotation="0"` attribute instead of separate rotX/Y/Z, this fix should help old maps open and save without errors

before:

https://github.com/user-attachments/assets/b5811222-c47e-4f96-9366-a5a5ab9750c6


after:

https://github.com/user-attachments/assets/59b022df-da5a-4fc8-8dee-3fb1ab8ad9d6

