### PR TITLE
Fix typos, missing Render Target resets, and nil boundary checks in gps

### DIFF
--- a/[gameplay]/gps/gps.lua
+++ b/[gameplay]/gps/gps.lua
@@ -12,25 +12,34 @@ end
 
 local function getNodeByID(db, nodeID)
 	local areaID = floor(nodeID / 65536)
-	return db[areaID][nodeID]
+	if db and db[areaID] then
+		return db[areaID][nodeID]
+	end
+	return nil
 end
 
 local function findNodeClosestToPoint(db, x, y, z)
 	local areaID = getAreaID(x, y)
 	local minDist, minNode
 	local nodeX, nodeY, dist
-	for id,node in pairs(db[areaID]) do
-		nodeX, nodeY = node.x, node.y
-		dist = (x - nodeX)*(x - nodeX) + (y - nodeY)*(y - nodeY)
-		if not minDist or dist < minDist then
-			minDist = dist
-			minNode = node
+	if db and db[areaID] then
+		for id,node in pairs(db[areaID]) do
+			nodeX, nodeY = node.x, node.y
+			dist = (x - nodeX)*(x - nodeX) + (y - nodeY)*(y - nodeY)
+			if not minDist or dist < minDist then
+				minDist = dist
+				minNode = node
+			end
 		end
 	end
 	return minNode
 end
 
 local function calculatePath(db, nodeFrom, nodeTo)
+	if not nodeFrom or not nodeTo then
+		return false
+	end
+
 	local next = next
 
 	local g = { [nodeFrom] = 0 }		-- { node = g }
@@ -67,16 +76,19 @@ local function calculatePath(db, nodeFrom, nodeTo)
 			break
 		end
 
-		local successors = {}
-		for id,distance in pairs(current.neighbours) do
-			local successor = getNodeByID(db, id)
-			local successor_g = g[current] + distance*distance
-			if not g[successor] or g[successor] > successor_g then
-				setmetatable(successor, nodeMT)
+		if current and current.neighbours then
+			for id,distance in pairs(current.neighbours) do
+				local successor = getNodeByID(db, id)
+				if successor then
+					local successor_g = g[current] + distance*distance
+					if not g[successor] or g[successor] > successor_g then
+						setmetatable(successor, nodeMT)
 
-				g[successor] = successor_g
-				openheap:insertvalue(successor)
-				parent[successor] = current
+						g[successor] = successor_g
+						openheap:insertvalue(successor)
+						parent[successor] = current
+					end
+				end
 			end
 		end
 	end
@@ -97,8 +109,12 @@ function calculatePathByCoords(x1, y1, z1, x2, y2, z2)
 	if not tonumber(x1) or not tonumber(y1) or not tonumber(x2) or not tonumber(y2) then
 		return false
 	end
-	return calculatePath(vehicleNodes, findNodeClosestToPoint(vehicleNodes, tonumber(x1), tonumber(y1), tonumber(z1)),
-	findNodeClosestToPoint(vehicleNodes, tonumber(x2), tonumber(y2), tonumber(z2)))
+	local fromNode = findNodeClosestToPoint(vehicleNodes, tonumber(x1), tonumber(y1), tonumber(z1))
+	local toNode = findNodeClosestToPoint(vehicleNodes, tonumber(x2), tonumber(y2), tonumber(z2))
+	if fromNode and toNode then
+		return calculatePath(vehicleNodes, fromNode, toNode)
+	end
+	return false
 end
 
 function calculatePathByNodeIDs(node1, node2)
@@ -117,7 +133,7 @@ end
 addEvent('onServerCall', true)
 addEventHandler('onServerCall', root,
 	function(fnName, ...)
-		if allowedRPC[fnName] then
+		if allowedRPC[fnName] and _G[fnName] then
 			_G[fnName](...)
 		end
 	end
@@ -126,7 +142,7 @@ addEventHandler('onServerCall', root,
 addEvent('onServerCallback', true)
 addEventHandler('onServerCallback', root,
 	function(crID, fnName, ...)
-		if allowedRPC[fnName] then
+		if allowedRPC[fnName] and _G[fnName] then
 			triggerClientEvent(source, 'onServerCallbackReply', resourceRoot, crID, _G[fnName](...))
 		end
 	end

--- a/[gameplay]/gps/linedrawer.lua
+++ b/[gameplay]/gps/linedrawer.lua
@@ -21,7 +21,7 @@ function removeLinePoints ( )
 end
 
 function addLinePoint ( posX, posY )
-	if not tonumber(posX) and not tonumber(poxY) then
+	if not tonumber(posX) or not tonumber(posY) then
 		return false
 	end
 	-- Calculate the row and column of the radar tile we will be targeting
@@ -58,6 +58,10 @@ function addLinePoint ( posX, posY )
 end
 
 function loadTile ( name )
+	if not linePoints[name] or not linePoints[name][1] then
+		return false
+	end
+
 	-- Create our fabulous shader. Abort on failure
 	local shader = dxCreateShader ( "overlay.fx" )
 	if not shader then
@@ -75,7 +79,7 @@ function loadTile ( name )
 	dxSetShaderValue ( shader, "gOverlay", rt )
 
 	-- Start drawing
-	dxSetRenderTarget ( rt )
+	dxSetRenderTarget ( rt, true )
 
 	-- Get the points involved, and get the starting position
 	local points = linePoints [ name ]
@@ -99,6 +103,9 @@ function loadTile ( name )
 		prevY = newY
 	end
 
+	-- Reset render target back to default screen
+	dxSetRenderTarget ( )
+
 	-- Now let's show our fabulous work to the commoners!
 	engineApplyShaderToWorldTexture ( shader, name )
 
@@ -110,9 +117,16 @@ function loadTile ( name )
 end
 
 function unloadTile ( name )
-	destroyElement ( renderStuff[name].shader )
-	destroyElement ( renderStuff[name].rt )
-	renderStuff[name] = nil
+	if renderStuff[name] then
+		if isElement(renderStuff[name].shader) then
+			engineRemoveShaderFromWorldTexture(renderStuff[name].shader, name)
+			destroyElement ( renderStuff[name].shader )
+		end
+		if isElement(renderStuff[name].rt) then
+			destroyElement ( renderStuff[name].rt )
+		end
+		renderStuff[name] = nil
+	end
 	return true
 end
 

--- a/[gameplay]/gps/util.lua
+++ b/[gameplay]/gps/util.lua
@@ -4,11 +4,14 @@ local _resume = coroutine.resume
 function coroutine.resume(cr, ...)
 	local ret = { _resume(cr, ...) }
 	if coroutine.status(cr) == 'dead' then
-		CRs[CRs[cr]] = nil
+		local id = CRs[cr]
+		if id then
+			CRs[id] = nil
+		end
 		CRs[cr] = nil
 	end
 	if not ret[1] then
-		outputDebugString(ret[2], 1)
+		outputDebugString(tostring(ret[2]), 1)
 		return false
 	end
 	table.remove(ret, 1)
@@ -18,7 +21,8 @@ end
 local serverMT = {}
 function serverMT:__index(fnName)
 	return function(...)
-		triggerServerEvent('onServerCallback', localPlayer, CRs[coroutine.running()], fnName, ...)
+		local cr = coroutine.running()
+		triggerServerEvent('onServerCallback', localPlayer, CRs[cr], fnName, ...)
 		return coroutine.yield()
 	end
 end
@@ -27,7 +31,9 @@ server = setmetatable({}, serverMT)
 addEvent('onServerCallbackReply', true)
 addEventHandler('onServerCallbackReply', resourceRoot,
 	function(crID, ...)
-		coroutine.resume(CRs[crID], ...)
+		if CRs[crID] then
+			coroutine.resume(CRs[crID], ...)
+		end
 	end,
 	false
 )
@@ -69,8 +75,10 @@ function table.merge ( ... )
 	local ret = { }
 
 	for index, tbl in ipairs ( {...} ) do
-		for index2, val in ipairs ( tbl ) do
-			table.insert ( ret, val )
+		if type(tbl) == "table" then
+			for index2, val in ipairs ( tbl ) do
+				table.insert ( ret, val )
+			end
 		end
 	end
 


### PR DESCRIPTION
- Corrected `poxY` to `posY` parameter validation inside `addLinePoint` (`linedrawer.lua`).
- Added `dxSetRenderTarget()` reset after drawing radar overlay lines to prevent render context lock (`linedrawer.lua`).
- Added safeguards for `db[areaID]` checks when looking up vehicle nodes in `gps.lua` for coordinates near map boundaries.
- Corrected `CRs` reference removals upon coroutine dead state inside `util.lua`.