### PR TITLE
Fix event handler target root, nil element destruction, and type conversions in interiors

### DIFF
--- a/[gameplay]/interiors/interiorexp.lua
+++ b/[gameplay]/interiors/interiorexp.lua
@@ -69,11 +69,11 @@ local function interiorCreateMarkers ( resource )
 				setElementParent ( marker, entryInterior )
 				interiorMarkers[entryInterior] = marker
 				--
-				local dimension = tonumber(getElementData ( entryInterior, "dimension" )) or 0
-				local interior = tonumber(getElementData ( entryInterior, "interior" )) or 0
+				local entDimension = tonumber(getElementData ( entryInterior, "dimension" )) or 0
+				local entInterior = tonumber(getElementData ( entryInterior, "interior" )) or 0
 				--
-				setElementInterior ( marker, interior )
-				setElementDimension ( marker, dimension )
+				setElementInterior ( marker, entInterior )
+				setElementDimension ( marker, entDimension )
 			end
 		end
 
@@ -90,11 +90,11 @@ local function interiorCreateMarkers ( resource )
 					interiorMarkers[returnInterior] = marker1
 					setElementParent ( marker1, returnInterior )
 					--
-					local dimension1 = tonumber(getElementData ( returnInterior, "dimension" )) or 0
-					local interior1 = tonumber(getElementData ( returnInterior, "interior" )) or 0
+					local retDimension = tonumber(getElementData ( returnInterior, "dimension" )) or 0
+					local retInterior = tonumber(getElementData ( returnInterior, "interior" )) or 0
 					--
-					setElementInterior ( marker1, interior1 )
-					setElementDimension ( marker1, dimension1 )
+					setElementInterior ( marker1, retInterior )
+					setElementDimension ( marker1, retDimension )
 				end
 			end
 		end

--- a/[gameplay]/interiors/interiorexp.lua
+++ b/[gameplay]/interiors/interiorexp.lua
@@ -8,6 +8,9 @@ addEvent ( "onPlayerInteriorWarped", true )
 addEvent ( "onInteriorHit" )
 addEvent ( "onInteriorWarped", true )
 
+-- Forward declaration
+local setPlayerInsideInterior
+
 addEventHandler ( "onResourceStart", root,
 function ( resource )
 	interiorLoadElements ( getResourceRootElement(resource), resource )
@@ -17,7 +20,7 @@ end )
 addEventHandler ( "onResourceStop", root,
 function ( resource )
 	if not interiors[resource] then return end
-	for id,interiorTable in pairs(interiors[resource]) do
+	for _, interiorTable in pairs(interiors[resource]) do
 		local interior1 = interiorTable["entry"]
 		local interior2 = interiorTable["return"]
 		if interiorMarkers[interior1] and isElement(interiorMarkers[interior1]) then
@@ -30,10 +33,10 @@ function ( resource )
 	interiors[resource] = nil
 end )
 
-function interiorLoadElements ( rootElement, resource )
+local function interiorLoadElements ( rootElement, resource )
 	---Load the exterior markers
 	local entryInteriors = getElementsByType ( "interiorEntry", rootElement )
-	for key, interior in pairs (entryInteriors) do
+	for _, interior in pairs (entryInteriors) do
 		local id = getElementData ( interior, "id" )
 		if not interiors[resource] then interiors[resource] = {} end
 		if not id then outputDebugString ( "Interiors: Error, no ID specified on entryInterior. Trying to load anyway.", 2 )
@@ -43,7 +46,7 @@ function interiorLoadElements ( rootElement, resource )
 	end
 	--Load the interior markers
 	local returnInteriors = getElementsByType ( "interiorReturn", rootElement )
-	for key, interior in pairs (returnInteriors) do
+	for _, interior in pairs (returnInteriors) do
 		local id = getElementData ( interior, "refid" )
 		if not interiors[resource] or not interiors[resource][id] then 
 			outputDebugString ( "Interiors: Error, no refid specified to returnInterior.", 1 )
@@ -53,9 +56,9 @@ function interiorLoadElements ( rootElement, resource )
 	end
 end
 
-function interiorCreateMarkers ( resource )
+local function interiorCreateMarkers ( resource )
 	if not interiors[resource] then return end
-	for interiorID, interiorTypeTable in pairs(interiors[resource]) do
+	for _, interiorTypeTable in pairs(interiors[resource]) do
 		local entryInterior = interiorTypeTable["entry"]
 		if entryInterior then
 			local entX,entY,entZ = getElementData ( entryInterior, "posX" ),getElementData ( entryInterior, "posY" ),getElementData ( entryInterior, "posZ" )
@@ -108,7 +111,6 @@ function getInteriorMarker ( elementInterior )
 	return false
 end
 
-local idLoc = { ["interiorReturn"] = "refid",["interiorEntry"] = "id" }
 addEventHandler ( "doTriggerServerEvents", root,
 	function( interior, resourceName, id )
 		if not isElement(client) then return end
@@ -122,7 +124,7 @@ addEventHandler ( "doTriggerServerEvents", root,
 )
 
 local opposite = { ["interiorReturn"] = "entry",["interiorEntry"] = "return" }
-function setPlayerInsideInterior ( player, interior, resourceName, id )
+setPlayerInsideInterior = function ( player, interior, resourceName, id )
 	if not isElement(player) then return end
 	local res = getResourceFromName(resourceName) or getThisResource()
 	if not interiors[res] or not interiors[res][id] then return end
@@ -148,5 +150,3 @@ function getInteriorName ( interior )
 		return false
 	end
 end
-
-

--- a/[gameplay]/interiors/interiorexp.lua
+++ b/[gameplay]/interiors/interiorexp.lua
@@ -48,7 +48,7 @@ local function interiorLoadElements ( rootElement, resource )
 	local returnInteriors = getElementsByType ( "interiorReturn", rootElement )
 	for _, interior in pairs (returnInteriors) do
 		local id = getElementData ( interior, "refid" )
-		if not interiors[resource] or not interiors[resource][id] then 
+		if not interiors[resource] or not interiors[resource][id] then
 			outputDebugString ( "Interiors: Error, no refid specified to returnInterior.", 1 )
 		else
 			interiors[resource][id]["return"] = interior

--- a/[gameplay]/interiors/interiorexp.lua
+++ b/[gameplay]/interiors/interiorexp.lua
@@ -20,29 +20,33 @@ function ( resource )
 	for id,interiorTable in pairs(interiors[resource]) do
 		local interior1 = interiorTable["entry"]
 		local interior2 = interiorTable["return"]
-		destroyElement ( interiorMarkers[interior1] )
-		destroyElement ( interiorMarkers[interior2] )
+		if interiorMarkers[interior1] and isElement(interiorMarkers[interior1]) then
+			destroyElement ( interiorMarkers[interior1] )
+		end
+		if interiorMarkers[interior2] and isElement(interiorMarkers[interior2]) then
+			destroyElement ( interiorMarkers[interior2] )
+		end
 	end
 	interiors[resource] = nil
 end )
 
-function interiorLoadElements ( root, resource )
+function interiorLoadElements ( rootElement, resource )
 	---Load the exterior markers
-	local entryInteriors = getElementsByType ( "interiorEntry", root )
+	local entryInteriors = getElementsByType ( "interiorEntry", rootElement )
 	for key, interior in pairs (entryInteriors) do
 		local id = getElementData ( interior, "id" )
 		if not interiors[resource] then interiors[resource] = {} end
-		if not id then outputDebugString ( "Interiors: Error, no ID specified on entryInterior.  Trying to load anyway.", 2 )
+		if not id then outputDebugString ( "Interiors: Error, no ID specified on entryInterior. Trying to load anyway.", 2 )
 		end
 		interiors[resource][id] = {}
 		interiors[resource][id]["entry"] = interior
 	end
 	--Load the interior markers
-	local returnInteriors = getElementsByType ( "interiorReturn", root )
+	local returnInteriors = getElementsByType ( "interiorReturn", rootElement )
 	for key, interior in pairs (returnInteriors) do
 		local id = getElementData ( interior, "refid" )
-		if not interiors[resource][id] then outputDebugString ( "Interiors: Error, no refid specified to returnInterior.", 1 )
-			return
+		if not interiors[resource] or not interiors[resource][id] then 
+			outputDebugString ( "Interiors: Error, no refid specified to returnInterior.", 1 )
 		else
 			interiors[resource][id]["return"] = interior
 		end
@@ -53,85 +57,94 @@ function interiorCreateMarkers ( resource )
 	if not interiors[resource] then return end
 	for interiorID, interiorTypeTable in pairs(interiors[resource]) do
 		local entryInterior = interiorTypeTable["entry"]
-		local entX,entY,entZ = getElementData ( entryInterior, "posX" ),getElementData ( entryInterior, "posY" ),getElementData ( entryInterior, "posZ" )
-		entX,entY,entZ = tonumber(entX),tonumber(entY),tonumber(entZ)
-		--
-		local marker = createMarker ( entX, entY, entZ + 2.2, "arrow", 2, 255, 255, 0, 200 )
-		setElementParent ( marker, entryInterior )
-		interiorMarkers[entryInterior] = marker
-		--
-		local dimension = tonumber(getElementData ( entryInterior, "dimension" ))
-		local interior = tonumber(getElementData ( entryInterior, "interior" ))
-		if not dimension then dimension = 0 end
-		if not interior then interior = 0 end
-		--
-		setElementInterior ( marker, interior )
-		setElementDimension ( marker, dimension )
+		if entryInterior then
+			local entX,entY,entZ = getElementData ( entryInterior, "posX" ),getElementData ( entryInterior, "posY" ),getElementData ( entryInterior, "posZ" )
+			entX,entY,entZ = tonumber(entX),tonumber(entY),tonumber(entZ)
+			
+			if entX and entY and entZ then
+				local marker = createMarker ( entX, entY, entZ + 2.2, "arrow", 2, 255, 255, 0, 200 )
+				setElementParent ( marker, entryInterior )
+				interiorMarkers[entryInterior] = marker
+				--
+				local dimension = tonumber(getElementData ( entryInterior, "dimension" )) or 0
+				local interior = tonumber(getElementData ( entryInterior, "interior" )) or 0
+				--
+				setElementInterior ( marker, interior )
+				setElementDimension ( marker, dimension )
+			end
+		end
+
 		---create return markers
 		local returnInterior = interiorTypeTable["return"]
-		local retX,retY,retZ = getElementData ( returnInterior, "posX" ),getElementData ( returnInterior, "posY" ),getElementData ( returnInterior, "posZ" )
-		retX,retY,retZ = tonumber(retX),tonumber(retY),tonumber(retZ)
-		--
-		local oneway = getElementData ( entryInterior, "oneway" )
-		if oneway == "true" then return end
-		local marker1 = createMarker ( retX, retY, retZ + 2.2, "arrow", 2, 255, 255, 0, 200 )
-		interiorMarkers[returnInterior] = marker1
-		setElementParent ( marker1, returnInterior )
-		--
-		local dimension1 = tonumber(getElementData ( returnInterior, "dimension" ))
-		local interior1 = tonumber(getElementData ( returnInterior, "interior" ))
-		if not dimension1 then dimension1 = 0 end
-		if not interior1 then interior1 = 0 end
-		--
-		setElementInterior ( marker1, interior1 )
-		setElementDimension ( marker1, dimension1 )
+		if returnInterior then
+			local oneway = getElementData ( entryInterior, "oneway" )
+			if oneway ~= "true" then
+				local retX,retY,retZ = getElementData ( returnInterior, "posX" ),getElementData ( returnInterior, "posY" ),getElementData ( returnInterior, "posZ" )
+				retX,retY,retZ = tonumber(retX),tonumber(retY),tonumber(retZ)
+				
+				if retX and retY and retZ then
+					local marker1 = createMarker ( retX, retY, retZ + 2.2, "arrow", 2, 255, 255, 0, 200 )
+					interiorMarkers[returnInterior] = marker1
+					setElementParent ( marker1, returnInterior )
+					--
+					local dimension1 = tonumber(getElementData ( returnInterior, "dimension" )) or 0
+					local interior1 = tonumber(getElementData ( returnInterior, "interior" )) or 0
+					--
+					setElementInterior ( marker1, interior1 )
+					setElementDimension ( marker1, dimension1 )
+				end
+			end
+		end
 	end
 end
 
 function getInteriorMarker ( elementInterior )
-	if not isElement ( elementInterior ) then outputDebugString("getInteriorName: Invalid variable specified as interior.  Element expected, got "..type(elementInterior)..".",0,255,128,0) return false end
+	if not isElement ( elementInterior ) then outputDebugString("getInteriorName: Invalid variable specified as interior. Element expected, got "..type(elementInterior)..".",0,255,128,0) return false end
 	local elemType = getElementType ( elementInterior )
 	if elemType == "interiorEntry" or elemType == "interiorReturn" then
 		return interiorMarkers[elementInterior] or false
 	end
-	outputDebugString("getInteriorName: Bad element specified.  Interior expected, got "..elemType..".",0,255,128,0)
+	outputDebugString("getInteriorName: Bad element specified. Interior expected, got "..elemType..".",0,255,128,0)
 	return false
 end
 
 local idLoc = { ["interiorReturn"] = "refid",["interiorEntry"] = "id" }
-addEventHandler ( "doTriggerServerEvents",root,
-	function( interior, resource, id )
-		local eventCanceled1, eventCanceled2
-		eventCanceled1 = triggerEvent ( "onPlayerInteriorHit", client, interior, resource, id )
-		eventCanceled2 = triggerEvent ( "onInteriorHit", interior, client )
+addEventHandler ( "doTriggerServerEvents", root,
+	function( interior, resourceName, id )
+		if not isElement(client) then return end
+		local eventCanceled1 = triggerEvent ( "onPlayerInteriorHit", client, interior, resourceName, id )
+		local eventCanceled2 = triggerEvent ( "onInteriorHit", interior, client )
 		if ( eventCanceled2 ) and ( eventCanceled1 ) then
-			triggerClientEvent ( client, "doWarpPlayerToInterior", client, interior, resource, id )
-			setTimer ( setPlayerInsideInterior, 1000, 1, client, interior, resource, id )
+			triggerClientEvent ( client, "doWarpPlayerToInterior", client, interior, resourceName, id )
+			setTimer ( setPlayerInsideInterior, 1000, 1, client, interior, resourceName, id )
 		end
 	end
 )
 
 local opposite = { ["interiorReturn"] = "entry",["interiorEntry"] = "return" }
-function setPlayerInsideInterior ( player, interior, resource, id )
+function setPlayerInsideInterior ( player, interior, resourceName, id )
+	if not isElement(player) then return end
+	local res = getResourceFromName(resourceName) or getThisResource()
+	if not interiors[res] or not interiors[res][id] then return end
 	local oppositeType = opposite[getElementType(interior)]
-	local targetInterior = interiors[getResourceFromName(resource) or getThisResource()][id][oppositeType]
-	local dim = getElementData ( targetInterior, "dimension" )
-	local int = getElementData ( targetInterior, "interior" )
-	if (isElement(player)) then
-		setElementInterior ( player, int )
-		setElementDimension ( player, dim )
-	end
+	local targetInterior = interiors[res][id][oppositeType]
+	if not targetInterior then return end
+
+	local dim = tonumber(getElementData ( targetInterior, "dimension" )) or 0
+	local int = tonumber(getElementData ( targetInterior, "interior" )) or 0
+	setElementInterior ( player, int )
+	setElementDimension ( player, dim )
 end
 
 function getInteriorName ( interior )
-	if not isElement ( interior ) then outputDebugString("getInteriorName: Invalid variable specified as interior.  Element expected, got "..type(interior)..".",0,255,128,0) return false end
+	if not isElement ( interior ) then outputDebugString("getInteriorName: Invalid variable specified as interior. Element expected, got "..type(interior)..".",0,255,128,0) return false end
 	local elemType = getElementType ( interior )
 	if elemType == "interiorEntry" then
 		return getElementData ( interior, "id" )
 	elseif elemType == "interiorReturn" then
 		return getElementData ( interior, "refid" )
 	else
-		outputDebugString("getInteriorName: Bad element specified.  Interior expected, got "..elemType..".",0,255,128,0)
+		outputDebugString("getInteriorName: Bad element specified. Interior expected, got "..elemType..".",0,255,128,0)
 		return false
 	end
 end

--- a/[gameplay]/interiors/interiors_client.lua
+++ b/[gameplay]/interiors/interiors_client.lua
@@ -69,30 +69,34 @@ function ( resource )
 	for id,interiorTable in pairs(interiors[resource]) do
 		local interior1 = interiorTable["entry"]
 		local interior2 = interiorTable["return"]
-		destroyElement ( interiorCols[interior1] )
-		destroyElement ( interiorCols[interior2] )
+		if interiorCols[interior1] and isElement(interiorCols[interior1]) then
+			destroyElement ( interiorCols[interior1] )
+		end
+		if interiorCols[interior2] and isElement(interiorCols[interior2]) then
+			destroyElement ( interiorCols[interior2] )
+		end
 	end
 	interiors[resource] = nil
 end )
 
-function interiorLoadElements ( root, resource )
+function interiorLoadElements ( rootElement, resource )
 	---Load the exterior markers
-	local entryInteriors = getElementsByType ( "interiorEntry", root )
+	local entryInteriors = getElementsByType ( "interiorEntry", rootElement )
 	for key, interior in pairs (entryInteriors) do
 		local id = getElementData ( interior, "id" )
 		if not interiors[resource] then interiors[resource] = {} end
-		if not id then outputDebugString ( "Interiors: Error, no ID specified on entryInterior.  Trying to load anyway.", 2 )
+		if not id then outputDebugString ( "Interiors: Error, no ID specified on entryInterior. Trying to load anyway.", 2 )
 		end
 		interiors[resource][id] = {}
 		interiors[resource][id]["entry"] = interior
 		resourceFromInterior[interior] = resource
 	end
 	--Load the interior markers
-	local returnInteriors = getElementsByType ( "interiorReturn", root )
+	local returnInteriors = getElementsByType ( "interiorReturn", rootElement )
 	for key, interior in pairs (returnInteriors) do
 		local id = getElementData ( interior, "refid" )
-		if not interiors[resource][id] then outputDebugString ( "Interiors: Error, no refid specified to returnInterior.", 1 )
-			return
+		if not interiors[resource] or not interiors[resource][id] then 
+			outputDebugString ( "Interiors: Error, no refid specified to returnInterior.", 1 )
 		else
 			interiors[resource][id]["return"] = interior
 			resourceFromInterior[interior] = resource
@@ -104,53 +108,58 @@ function interiorCreateMarkers ( resource )
 	if not interiors[resource] then return end
 	for interiorID, interiorTypeTable in pairs(interiors[resource]) do
 		local entryInterior = interiorTypeTable["entry"]
-		local entX,entY,entZ = getElementData ( entryInterior, "posX" ),getElementData ( entryInterior, "posY" ),getElementData ( entryInterior, "posZ" )
-		entX,entY,entZ = tonumber(entX),tonumber(entY),tonumber(entZ)
-		--
-		local col = createColSphere ( entX, entY, entZ, 1.5 )
-		setElementParent ( col, entryInterior )
-		interiorCols[entryInterior] = col
-		interiorFromCol[col] = entryInterior
-		addEventHandler ( "onClientColShapeHit", col, colshapeHit )
-		--
-		local dimension = tonumber(getElementData ( entryInterior, "dimension" ))
-		local interior = tonumber(getElementData ( entryInterior, "interior" ))
-		if not dimension then dimension = 0 end
-		if not interior then interior = 0 end
-		--
-		setElementInterior ( col, interior )
-		setElementDimension ( col, dimension )
+		if entryInterior then
+			local entX,entY,entZ = getElementData ( entryInterior, "posX" ),getElementData ( entryInterior, "posY" ),getElementData ( entryInterior, "posZ" )
+			entX,entY,entZ = tonumber(entX),tonumber(entY),tonumber(entZ)
+			
+			if entX and entY and entZ then
+				local col = createColSphere ( entX, entY, entZ, 1.5 )
+				setElementParent ( col, entryInterior )
+				interiorCols[entryInterior] = col
+				interiorFromCol[col] = entryInterior
+				addEventHandler ( "onClientColShapeHit", col, colshapeHit )
+				--
+				local dimension = tonumber(getElementData ( entryInterior, "dimension" )) or 0
+				local interior = tonumber(getElementData ( entryInterior, "interior" )) or 0
+				--
+				setElementInterior ( col, interior )
+				setElementDimension ( col, dimension )
+			end
+		end
+
 		---create return markers
 		local returnInterior = interiorTypeTable["return"]
-		local retX,retY,retZ = getElementData ( returnInterior, "posX" ),getElementData ( returnInterior, "posY" ),getElementData ( returnInterior, "posZ" )
-		retX,retY,retZ = tonumber(retX),tonumber(retY),tonumber(retZ)
-		--
-		local oneway = getElementData ( entryInterior, "oneway" )
-		if oneway == "true" then return end
-		--
-		local col1 = createColSphere ( retX, retY, retZ, 1.5 )
-		interiorFromCol[col1] = returnInterior
-		interiorCols[returnInterior] = col1
-		setElementParent ( col1, returnInterior )
-		addEventHandler ( "onClientColShapeHit", col1, colshapeHit )
-		--
-		local dimension1 = tonumber(getElementData ( returnInterior, "dimension" ))
-		local interior1 = tonumber(getElementData ( returnInterior, "interior" ))
-		if not dimension1 then dimension1 = 0 end
-		if not interior1 then interior1 = 0 end
-		--
-		setElementInterior ( col1, interior1 )
-		setElementDimension ( col1, dimension1 )
+		if returnInterior then
+			local oneway = getElementData ( entryInterior, "oneway" )
+			if oneway ~= "true" then
+				local retX,retY,retZ = getElementData ( returnInterior, "posX" ),getElementData ( returnInterior, "posY" ),getElementData ( returnInterior, "posZ" )
+				retX,retY,retZ = tonumber(retX),tonumber(retY),tonumber(retZ)
+				
+				if retX and retY and retZ then
+					local col1 = createColSphere ( retX, retY, retZ, 1.5 )
+					interiorFromCol[col1] = returnInterior
+					interiorCols[returnInterior] = col1
+					setElementParent ( col1, returnInterior )
+					addEventHandler ( "onClientColShapeHit", col1, colshapeHit )
+					--
+					local dimension1 = tonumber(getElementData ( returnInterior, "dimension" )) or 0
+					local interior1 = tonumber(getElementData ( returnInterior, "interior" )) or 0
+					--
+					setElementInterior ( col1, interior1 )
+					setElementDimension ( col1, dimension1 )
+				end
+			end
+		end
 	end
 end
 
 function getInteriorMarker ( elementInterior )
-	if not isElement ( elementInterior ) then outputDebugString("getInteriorName: Invalid variable specified as interior.  Element expected, got "..type(elementInterior)..".",0,255,128,0) return false end
+	if not isElement ( elementInterior ) then outputDebugString("getInteriorName: Invalid variable specified as interior. Element expected, got "..type(elementInterior)..".",0,255,128,0) return false end
 	local elemType = getElementType ( elementInterior )
 	if elemType == "interiorEntry" or elemType == "interiorReturn" then
-		return interiorMarkers[elementInterior] or false
+		return interiorCols[elementInterior] or false
 	end
-	outputDebugString("getInteriorName: Bad element specified.  Interior expected, got "..elemType..".",0,255,128,0)
+	outputDebugString("getInteriorName: Bad element specified. Interior expected, got "..elemType..".",0,255,128,0)
 	return false
 end
 
@@ -166,40 +175,44 @@ function colshapeHit( player, matchingDimension )
 	( isPedDoingTask ( player, "TASK_COMPLEX_ENTER_CAR_AS_PASSENGER") )
 	then return end
 	local interior = interiorFromCol[source]
+	if not interior then return end
 	local id = getElementData ( interior, idLoc[getElementType(interior)] )
 	local resource = resourceFromInterior[interior]
-	eventCanceled = triggerEvent ( "onClientInteriorHit", interior )
+	local eventCanceled = triggerEvent ( "onClientInteriorHit", interior )
 	if ( eventCanceled ) then
 		triggerServerEvent ( "doTriggerServerEvents", localPlayer, interior, getResourceName(resource), id )
 	end
 end
 
-addEventHandler ( "doWarpPlayerToInterior",localPlayer,
-	function ( interior, resource, id )
-		resource = getResourceFromName(resource)
+addEventHandler ( "doWarpPlayerToInterior", root,
+	function ( interior, resourceName, id )
+		local res = getResourceFromName(resourceName)
+		if not res or not interiors[res] or not interiors[res][id] then return end
 		local oppositeType = opposite[getElementType(interior)]
-		local targetInterior = interiors[resource][id][oppositeType]
+		local targetInterior = interiors[res][id][oppositeType]
+		if not targetInterior then return end
 
-		local x = getElementData ( targetInterior, "posX" )
-		local y = getElementData ( targetInterior, "posY" )
-		local z = getElementData ( targetInterior, "posZ" ) + 1
-		local dim = getElementData ( targetInterior, "dimension" )
-		local int = getElementData ( targetInterior, "interior" )
-		local rot = getElementData ( targetInterior, "rotation" )
+		local x = tonumber(getElementData ( targetInterior, "posX" )) or 0
+		local y = tonumber(getElementData ( targetInterior, "posY" )) or 0
+		local z = (tonumber(getElementData ( targetInterior, "posZ" )) or 0) + 1
+		local dim = tonumber(getElementData ( targetInterior, "dimension" )) or 0
+		local int = tonumber(getElementData ( targetInterior, "interior" )) or 0
+		local rot = tonumber(getElementData ( targetInterior, "rotation" )) or 0
 		toggleAllControls ( false, true, false )
 		fadeCamera ( false, 1.0 )
-		setTimer ( setPlayerInsideInterior, 1000, 1, source, int,dim,rot,x,y,z, interior )
+		setTimer ( setPlayerInsideInterior, 1000, 1, localPlayer, int, dim, rot, x, y, z, interior )
 		blockPlayer = true
 		setTimer ( function() blockPlayer = nil end, 3500, 1 )
 	end
 )
 
-function setPlayerInsideInterior ( player, int,dim,rot,x,y,z, interior )
+function setPlayerInsideInterior ( player, int, dim, rot, x, y, z, interior )
+	if not isElement(player) then return end
 	setElementInterior ( player, int )
 	setCameraInterior ( int )
 	setElementDimension ( player, dim )
-	setPedRotation ( player, rot%360 )
-	setTimer ( function(p) if isElement(p) then setCameraTarget(p) end end, 200,1, player )
+	setPedRotation ( player, rot % 360 )
+	setTimer ( function(p) if isElement(p) then setCameraTarget(p) end end, 200, 1, player )
 	setElementPosition ( player, x, y, z )
 	toggleAllControls ( true, true, false )
 	setTimer ( fadeCamera, 500, 1, true, 1.0 )
@@ -209,14 +222,14 @@ function setPlayerInsideInterior ( player, int,dim,rot,x,y,z, interior )
 end
 
 function getInteriorName ( interior )
-	if not isElement ( interior ) then outputDebugString("getInteriorName: Invalid variable specified as interior.  Element expected, got "..type(interior)..".",0,255,128,0) return false end
+	if not isElement ( interior ) then outputDebugString("getInteriorName: Invalid variable specified as interior. Element expected, got "..type(interior)..".",0,255,128,0) return false end
 	local elemType = getElementType ( interior )
 	if elemType == "interiorEntry" then
 		return getElementData ( interior, "id" )
 	elseif elemType == "interiorReturn" then
 		return getElementData ( interior, "refid" )
 	else
-		outputDebugString("getInteriorName: Bad element specified.  Interior expected, got "..elemType..".",0,255,128,0)
+		outputDebugString("getInteriorName: Bad element specified. Interior expected, got "..elemType..".",0,255,128,0)
 		return false
 	end
 end

--- a/[gameplay]/interiors/interiors_client.lua
+++ b/[gameplay]/interiors/interiors_client.lua
@@ -71,7 +71,7 @@ local function interiorLoadElements ( rootElement, resource )
 	local returnInteriors = getElementsByType ( "interiorReturn", rootElement )
 	for _, interior in pairs (returnInteriors) do
 		local id = getElementData ( interior, "refid" )
-		if not interiors[resource] or not interiors[resource][id] then 
+		if not interiors[resource] or not interiors[resource][id] then
 			outputDebugString ( "Interiors: Error, no refid specified to returnInterior.", 1 )
 		else
 			interiors[resource][id]["return"] = interior

--- a/[gameplay]/interiors/interiors_client.lua
+++ b/[gameplay]/interiors/interiors_client.lua
@@ -18,41 +18,17 @@ local setInteriorMarkerZ = {
 	end
 }
 
--- addEventHandler("onClientElementStreamIn",root,
-	-- function()
-		-- if getElementType ( source ) == "marker" then
-			-- local parent = getElementParent ( source )
-			-- local parentType = getElementType(parent)
-			-- if parentType == "interiorEntry" or parentType == "interiorReturn" then
-				-- interiorAnims[source] = Animation.createAndPlay(
-		-- source,
-		-- { from = 0, to = 2*math.pi, time = 2000, repeats = 0, transform = math.sin, fn = setInteriorMarkerZ[parentType] }
--- )
-			-- end
-		-- end
-	-- end
--- )
-
--- addEventHandler("onClientElementStreamOut",root,
-	-- function()
-		-- if getElementType ( source ) == "marker" then
-			-- local parent = getElementParent ( source )
-			-- local parentType = getElementType(parent)
-			-- if parentType == "interiorEntry" or parentType == "interiorReturn" then
-				-- if (interiorAnims[source] ) then
-					-- interiorAnims[source]:remove()
-				-- end
-			-- end
-		-- end
-	-- end
--- )
-
 ----Main
 local interiors = {}
 local interiorCols = {}
 local interiorFromCol = {}
 local resourceFromInterior = {}
 local blockPlayer
+
+-- Forward declarations
+local colshapeHit
+local setPlayerInsideInterior
+
 addEvent ( "doWarpPlayerToInterior", true )
 addEvent ( "onClientInteriorHit" )
 addEvent ( "onClientInteriorWarped" )
@@ -66,7 +42,7 @@ end )
 addEventHandler ( "onClientResourceStop", root,
 function ( resource )
 	if not interiors[resource] then return end
-	for id,interiorTable in pairs(interiors[resource]) do
+	for _, interiorTable in pairs(interiors[resource]) do
 		local interior1 = interiorTable["entry"]
 		local interior2 = interiorTable["return"]
 		if interiorCols[interior1] and isElement(interiorCols[interior1]) then
@@ -79,10 +55,10 @@ function ( resource )
 	interiors[resource] = nil
 end )
 
-function interiorLoadElements ( rootElement, resource )
+local function interiorLoadElements ( rootElement, resource )
 	---Load the exterior markers
 	local entryInteriors = getElementsByType ( "interiorEntry", rootElement )
-	for key, interior in pairs (entryInteriors) do
+	for _, interior in pairs (entryInteriors) do
 		local id = getElementData ( interior, "id" )
 		if not interiors[resource] then interiors[resource] = {} end
 		if not id then outputDebugString ( "Interiors: Error, no ID specified on entryInterior. Trying to load anyway.", 2 )
@@ -93,7 +69,7 @@ function interiorLoadElements ( rootElement, resource )
 	end
 	--Load the interior markers
 	local returnInteriors = getElementsByType ( "interiorReturn", rootElement )
-	for key, interior in pairs (returnInteriors) do
+	for _, interior in pairs (returnInteriors) do
 		local id = getElementData ( interior, "refid" )
 		if not interiors[resource] or not interiors[resource][id] then 
 			outputDebugString ( "Interiors: Error, no refid specified to returnInterior.", 1 )
@@ -104,9 +80,9 @@ function interiorLoadElements ( rootElement, resource )
 	end
 end
 
-function interiorCreateMarkers ( resource )
+local function interiorCreateMarkers ( resource )
 	if not interiors[resource] then return end
-	for interiorID, interiorTypeTable in pairs(interiors[resource]) do
+	for _, interiorTypeTable in pairs(interiors[resource]) do
 		local entryInterior = interiorTypeTable["entry"]
 		if entryInterior then
 			local entX,entY,entZ = getElementData ( entryInterior, "posX" ),getElementData ( entryInterior, "posY" ),getElementData ( entryInterior, "posZ" )
@@ -165,7 +141,7 @@ end
 
 local opposite = { ["interiorReturn"] = "entry",["interiorEntry"] = "return" }
 local idLoc = { ["interiorReturn"] = "refid",["interiorEntry"] = "id" }
-function colshapeHit( player, matchingDimension )
+colshapeHit = function( player, matchingDimension )
 	if not isElement ( player ) or getElementType ( player ) ~= "player" then return end
 	if player ~= localPlayer then return end
 	if ( not matchingDimension ) or ( getPedOccupiedVehicle ( player ) ) or
@@ -206,7 +182,7 @@ addEventHandler ( "doWarpPlayerToInterior", root,
 	end
 )
 
-function setPlayerInsideInterior ( player, int, dim, rot, x, y, z, interior )
+setPlayerInsideInterior = function ( player, int, dim, rot, x, y, z, interior )
 	if not isElement(player) then return end
 	setElementInterior ( player, int )
 	setCameraInterior ( int )
@@ -233,5 +209,3 @@ function getInteriorName ( interior )
 		return false
 	end
 end
-
-

--- a/[gameplay]/interiors/interiors_client.lua
+++ b/[gameplay]/interiors/interiors_client.lua
@@ -95,11 +95,11 @@ local function interiorCreateMarkers ( resource )
 				interiorFromCol[col] = entryInterior
 				addEventHandler ( "onClientColShapeHit", col, colshapeHit )
 				--
-				local dimension = tonumber(getElementData ( entryInterior, "dimension" )) or 0
-				local interior = tonumber(getElementData ( entryInterior, "interior" )) or 0
+				local entDimension = tonumber(getElementData ( entryInterior, "dimension" )) or 0
+				local entInterior = tonumber(getElementData ( entryInterior, "interior" )) or 0
 				--
-				setElementInterior ( col, interior )
-				setElementDimension ( col, dimension )
+				setElementInterior ( col, entInterior )
+				setElementDimension ( col, entDimension )
 			end
 		end
 
@@ -118,11 +118,11 @@ local function interiorCreateMarkers ( resource )
 					setElementParent ( col1, returnInterior )
 					addEventHandler ( "onClientColShapeHit", col1, colshapeHit )
 					--
-					local dimension1 = tonumber(getElementData ( returnInterior, "dimension" )) or 0
-					local interior1 = tonumber(getElementData ( returnInterior, "interior" )) or 0
+					local retDimension = tonumber(getElementData ( returnInterior, "dimension" )) or 0
+					local retInterior = tonumber(getElementData ( returnInterior, "interior" )) or 0
 					--
-					setElementInterior ( col1, interior1 )
-					setElementDimension ( col1, dimension1 )
+					setElementInterior ( col1, retInterior )
+					setElementDimension ( col1, retDimension )
 				end
 			end
 		end


### PR DESCRIPTION
- Updated `doWarpPlayerToInterior` event handler in `interiors_client.lua` to target `root` instead of `localPlayer` so server triggers execute properly.
- Added `isElement` checks before destroying markers and colshapes during resource cleanup to avoid runtime errors on one-way or missing markers.
- Safe-cast coordinates, dimensions, and rotation parameters with `tonumber` to prevent arithmetic type mismatch errors when calculating player rotation.
- Implemented `isElement(player)` validation inside asynchronous timer callbacks (`setPlayerInsideInterior`) to prevent server warnings if a player quits mid-warp.