### PR TITLE
Revert "mapfixes: add model transparency fixes"

### DIFF
--- a/[gameplay]/mapfixes/meta.xml
+++ b/[gameplay]/mapfixes/meta.xml
@@ -1,6 +1,6 @@
 <meta>
 	<info author="MTA contributors (github.com/multitheftauto/mtasa-resources)" version="1.0" name="SA Map Fixes" description="This resource patches a few flaws in the default MTA world" type="script" />
-	<min_mta_version client="1.7.0-9.25613.0" server="1.6.0-9.22505.0"></min_mta_version>
+	<min_mta_version client="1.6.0-9.22505.0" server="1.6.0-9.22505.0"></min_mta_version>
 
 	<script src="scripts/shared/data.lua" type="shared"/>
 	<script src="scripts/client/main.lua" type="client"/>
@@ -12,6 +12,5 @@
 		<setting name="*atrium_lobby_interior" value="[true]" friendlyname="Atrium Lobby Interior" desc="Enable Commerce Atrium lobby open-world interior" accept="true,false"/>
 		<setting name="*doherty_garage_interior" value="[true]" friendlyname="Doherty Garage Interior" desc="Enable Doherty Safehouse Garage open-world interior" accept="true,false"/>
 		<setting name="*undamaged_crackfactory_with_interior" friendlyname="Undamaged SF Crack Factory" value="[true]" desc="Enable restored Undamaged SF Crack Factory with open-world interior" accept="true,false"/>
-		<setting name="*model_transparency_fixes" friendlyname="Model Transparency Fixes" value="[true]" desc="Apply some fixes to certain models which have bugged transparency in GTA" accept="true,false"/>
 	</settings>
 </meta>

--- a/[gameplay]/mapfixes/scripts/client/main.lua
+++ b/[gameplay]/mapfixes/scripts/client/main.lua
@@ -1,7 +1,7 @@
 addEvent("mapfixes:client:loadAllComponents", true)
 addEvent("mapfixes:client:togOneComponent", true)
 
-local function loadOneMapFixComponent(name, data, wasToggled)
+local function loadOneMapFixComponent(name, data)
     -- Clear the previous elements if any
     local createdElements = data.createdElements
     if createdElements then
@@ -34,13 +34,10 @@ local function loadOneMapFixComponent(name, data, wasToggled)
             setGarageOpen(garageID, false)
         end
     end
-    -- Revert previously set model flags
-    local modelFlagsToSet = data.modelFlagsToSet
-    if modelFlagsToSet then
-        for _, v in pairs(modelFlagsToSet) do
-            engineSetModelFlag(v[1], v[2], not v[3])
-			engineRestreamModel(v[1])
-        end
+
+    -- Don't proceed if the component is disabled
+    if not data.enabled then
+        return
     end
 
     -- Create the new elements if any
@@ -63,6 +60,7 @@ local function loadOneMapFixComponent(name, data, wasToggled)
                 if allocatedID then
                     if not data.allocatedIDs then data.allocatedIDs = {} end
                     data.allocatedIDs[#data.allocatedIDs + 1] = allocatedID
+
                     object = createObject(allocatedID, v.x, v.y, v.z, v.rx, v.ry, v.rz)
                     if object then
                         engineSetModelPhysicalPropertiesGroup(allocatedID, v.physicalPropertiesGroup)
@@ -96,13 +94,6 @@ local function loadOneMapFixComponent(name, data, wasToggled)
             setGarageOpen(garageID, true)
         end
     end
-    -- Set model flags if any
-    if modelFlagsToSet then
-        for _, v in pairs(modelFlagsToSet) do
-            engineSetModelFlag(v[1], v[2], v[3])
-			engineRestreamModel(v[1])
-        end
-    end
 end
 
 local function loadMapFixComponents(mapFixComponentStatuses)
@@ -125,7 +116,7 @@ local function toggleOneMapFixComponent(name, enable)
         return
     end
     data.enabled = (enable == true)
-    loadOneMapFixComponent(name, data, true)
+    loadOneMapFixComponent(name, data)
     if eventName ~= "onClientResourceStop" then
         outputDebugString("Map fix component '" .. name .. "' is now " .. (data.enabled and "enabled" or "disabled"))
     end

--- a/[gameplay]/mapfixes/scripts/shared/data.lua
+++ b/[gameplay]/mapfixes/scripts/shared/data.lua
@@ -90,9 +90,4 @@ mapFixComponents = {
             { 11236, 25, -2164.4531, -255.39062, 38.125,   0 }, -- crackfactwalke
         },
     },
-    ["model_transparency_fixes"] = {
-        modelFlagsToSet = {
-            { 3089, 'draw_last', true }, -- ab_casdorLok (brown door with glass window)
-        }
-    },
 }


### PR DESCRIPTION
This has to wait until 1.7 is released otherwise when a 1.6 server pulls in the latest resources, they'll be forced to only accept 1.7 clients. cc @Fernando-A-Rocha @ArranTuna 

Original PR #590 